### PR TITLE
Feature/GitHub action Python formatting/linting #3

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
-max-line-length = 88
-extend-ignore = E203
+max-line-length = 120
+extend-ignore = E203, E402, E722
+per-file-ignores = __init__.py:F401

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-extend-ignore = E203, E402, E722
+extend-ignore = E203, E402, E722, W391
 per-file-ignores = __init__.py:F401

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -42,11 +42,12 @@ jobs:
           virtual-env: "python-lint-plus"
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.artchitecture }}
+          use-docformatter: false
+          use-pycodestyle: false
           use-black: true
           extra-black-options: "--line-length 120"
           use-isort: true
           extra-isort-options: "--profile black"
           use-flake8: true
           extra-flake8-options: "--max-line-length 120 --extend-ignore=E203,E402,E722 --per-file-ignores=__init__.py:F401"
-          use-docformatter: false
-          use-pycodestyle: false
+

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -44,7 +44,7 @@ jobs:
           black tests scripts sdkit examples --line-length 120 --include="\.py"
           isort tests scripts sdkit examples --profile black
           autoflake --in-place --remove-all-unused-imports --remove-unused-variables --recursive .
-          flake8 tests scripts sdkit examples --max-line-length 120 --extend-ignore=E203,E402,E722 --per-file-ignores=__init__.py:F401
+          flake8 tests scripts sdkit examples --max-line-length 120 --extend-ignore=E203,E402,E722,W391 --per-file-ignores=__init__.py:F401
 
       #----------------------------------------------
       #       Committing all changes

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -40,6 +40,5 @@ jobs:
           architecture: "x64"
           use-black: true
           use-isort: true
-          use-docformatter: true
           use-pydocstyle: true
           use-flake8: true

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -49,3 +49,4 @@ jobs:
           use-flake8: true
           extra-flake8-options: "--max-line-length 120 --extend-ignore=E203,E402,E722 --per-file-ignores=__init__.py:F401"
           use-docformatter: false
+          use-pycodestyle: false

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -39,5 +39,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: "x64"
           use-black: true
+          extra-black-options: "--line-length 120"
           use-isort: true
+          extra-isort-options: "--profile black"
           use-flake8: true
+          extra-flake8-options: "--max-line-length 120 --extend-ignore=E203,E402,E722 --per-file-ignores=__init__.py:F401"

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -3,10 +3,10 @@ name: Lint Python
 on:
   push:
     branches:
-      - "!master"
+      - "!main"
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   lintpython:

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         # apparently only ubuntu latest is available to run a contenairised job
-        os: [ubuntu-latest]
+        os: [windows-latest]
         python-version: ["3.9"]
         architecture: ["x64"]
 
@@ -50,4 +50,3 @@ jobs:
           extra-isort-options: "--profile black"
           use-flake8: true
           extra-flake8-options: "--max-line-length 120 --extend-ignore=E203,E402,E722 --per-file-ignores=__init__.py:F401"
-

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # apparently only ubuntu latest is available to run a contenairised job
+        os: [ubuntu-latest]
         python-version: ["3.9", "3.10"]
 
     steps:

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -48,3 +48,4 @@ jobs:
           extra-isort-options: "--profile black"
           use-flake8: true
           extra-flake8-options: "--max-line-length 120 --extend-ignore=E203,E402,E722 --per-file-ignores=__init__.py:F401"
+          use-docformatter: false

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -36,35 +36,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       #----------------------------------------------
-      #       Formatting
+      #       Formatting & Linting
       #----------------------------------------------
-      - name: Format code with black
+      - name: Format and lint the code
         run: |
-          pip install black
+          pip install black isort autoflake flake8
           black tests scripts sdkit examples --line-length 120 --include="\.py"
-
-      #----------------------------------------------
-      #       Sorting imports
-      #----------------------------------------------
-      - name: Sorting imports with isort
-        run: |
-          pip install isort
           isort tests scripts sdkit examples --profile black
-
-      #----------------------------------------------
-      #       Removing unused imports and variables
-      #----------------------------------------------
-      - name: Remove unused imports with autoflake
-        run: |
-          pip install autoflake
           autoflake --in-place --remove-all-unused-imports --remove-unused-variables --recursive .
-
-      #----------------------------------------------
-      #       Linting
-      #----------------------------------------------
-      - name: Linting code with flake8
-        run: |
-          pip install flake8
           flake8 tests scripts sdkit examples --max-line-length 120 --extend-ignore=E203,E402,E722 --per-file-ignores=__init__.py:F401
 
       #----------------------------------------------

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Linting stage
         uses: weibullguy/python-lint-plus@v1.11.0
         with:
-          python-root-list: "tests"
+          python-root-list: "examples scripts sdkit tests"
           virtual-env: "python-lint-plus"
           python-version: ${{ matrix.python-version }}
           architecture: "x64"

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -40,5 +40,4 @@ jobs:
           architecture: "x64"
           use-black: true
           use-isort: true
-          use-pydocstyle: true
           use-flake8: true

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -22,32 +22,59 @@ jobs:
 
     steps:
       #----------------------------------------------
-      #       check-out repo and set-up python
+      #       check-out repo
       #----------------------------------------------
       - name: Check out code
         uses: actions/checkout@v3
 
+      #----------------------------------------------
+      #       set-up python
+      #----------------------------------------------
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       #----------------------------------------------
-      #       Formatting and Linting
+      #       Formatting
       #----------------------------------------------
-      - name: Linting stage
-        uses: weibullguy/python-lint-plus@v1.11.0
-        with:
-          python-root-list: "examples scripts sdkit tests"
-          virtual-env: "python-lint-plus"
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.artchitecture }}
-          use-docformatter: false
-          use-pycodestyle: false
-          use-black: true
-          extra-black-options: "--line-length 120"
-          use-isort: true
-          extra-isort-options: "--profile black"
-          use-flake8: true
-          extra-flake8-options: "--max-line-length 120 --extend-ignore=E203,E402,E722 --per-file-ignores=__init__.py:F401"
+      - name: Format code with black
+        run: |
+          pip install black
+          black tests scripts sdkit examples --line-length 120 --include="\.py"
 
+      #----------------------------------------------
+      #       Sorting imports
+      #----------------------------------------------
+      - name: Sorting imports with isort
+        run: |
+          pip install isort
+          isort tests scripts sdkit examples --profile black
+
+      #----------------------------------------------
+      #       Removing unused imports and variables
+      #----------------------------------------------
+      - name: Remove unused imports with autoflake
+        run: |
+          pip install autoflake
+          autoflake --in-place --remove-all-unused-imports --remove-unused-variables --recursive .
+
+      #----------------------------------------------
+      #       Linting
+      #----------------------------------------------
+      - name: Linting code with flake8
+        run: |
+          pip install flake8
+          flake8 tests scripts sdkit examples --max-line-length 120 --extend-ignore=E203,E402,E722 --per-file-ignores=__init__.py:F401
+
+      #----------------------------------------------
+      #       Committing all changes
+      #----------------------------------------------
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v4
+        with:
+          author_name: ${{ github.actor }}
+          author_email: ${{ github.actor }}@users.noreply.github.com
+          message: "Code formatted and linted"
+          add: "."
+          branch: ${{ github.ref }}

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         # apparently only ubuntu latest is available to run a contenairised job
-        os: [windows-latest]
+        os: [ubuntu-latest]
         python-version: ["3.9"]
         architecture: ["x64"]
 
@@ -50,3 +50,4 @@ jobs:
           extra-isort-options: "--profile black"
           use-flake8: true
           extra-flake8-options: "--max-line-length 120 --extend-ignore=E203,E402,E722 --per-file-ignores=__init__.py:F401"
+

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -1,0 +1,44 @@
+name: Lint Python
+
+on:
+  push:
+    branches:
+      - "!master"
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  lintpython:
+    name: Lint Python
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10"]
+
+    steps:
+      #----------------------------------------------
+      #       check-out repo and set-up python
+      #----------------------------------------------
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Linting stage
+        uses: weibullguy/python-lint-plus@v1.11.0
+        with:
+          python-root-list: "tests"
+          virtual-env: "python-lint-plus"
+          python-version: ${{ matrix.python-version }}
+          architecture: "x64"
+          use-black: true
+          use-isort: true
+          use-docformatter: true
+          use-pydocstyle: true
+          use-flake8: true

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -44,7 +44,7 @@ jobs:
           black tests scripts sdkit examples --line-length 120 --include="\.py"
           isort tests scripts sdkit examples --profile black
           autoflake --in-place --remove-all-unused-imports --remove-unused-variables --recursive .
-          flake8 tests scripts sdkit examples --max-line-length 120 --extend-ignore=E203,E402,E722,W391 --per-file-ignores=__init__.py:F401
+          flake8 tests scripts sdkit examples --max-line-length 120 --extend-ignore=E203,E402,E501,E722,W391 --per-file-ignores=__init__.py:F401
 
       #----------------------------------------------
       #       Committing all changes

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -1,4 +1,4 @@
-name: Lint Python
+name: Python Linting
 
 on:
   push:
@@ -9,15 +9,16 @@ on:
       - main
 
 jobs:
-  lintpython:
-    name: Lint Python
+  linting:
+    name: Python Linting
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
         # apparently only ubuntu latest is available to run a contenairised job
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9"]
+        architecture: ["x64"]
 
     steps:
       #----------------------------------------------
@@ -31,13 +32,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      #----------------------------------------------
+      #       Formatting and Linting
+      #----------------------------------------------
       - name: Linting stage
         uses: weibullguy/python-lint-plus@v1.11.0
         with:
           python-root-list: "examples scripts sdkit tests"
           virtual-env: "python-lint-plus"
           python-version: ${{ matrix.python-version }}
-          architecture: "x64"
+          architecture: ${{ matrix.artchitecture }}
           use-black: true
           extra-black-options: "--line-length 120"
           use-isort: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,160 @@
-__pycache__
-sdkit.egg-info
-dist
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/examples/001-generate-model_file_on_disk.py
+++ b/examples/001-generate-model_file_on_disk.py
@@ -1,24 +1,18 @@
 import sdkit
-from sdkit.generate import generate_images
 from sdkit.models import load_model
-from sdkit.utils import log, save_images
+from sdkit.generate import generate_images
+from sdkit.utils import save_images, log
 
 context = sdkit.Context()
 
 # set the path to the model file on the disk (.ckpt or .safetensors file)
-context.model_paths["stable-diffusion"] = "D:\\path\\to\\512-base-ema.ckpt"
-load_model(context, "stable-diffusion")
+context.model_paths['stable-diffusion'] = 'D:\\path\\to\\512-base-ema.ckpt'
+load_model(context, 'stable-diffusion')
 
 # generate the image
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-)
+images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
 
 # save the image
-save_images(images, dir_path=".")
+save_images(images, dir_path='.')
 
 log.info("Generated images!")

--- a/examples/001-generate-model_file_on_disk.py
+++ b/examples/001-generate-model_file_on_disk.py
@@ -6,13 +6,13 @@ from sdkit.utils import log, save_images
 context = sdkit.Context()
 
 # set the path to the model file on the disk (.ckpt or .safetensors file)
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\512-base-ema.ckpt'
-load_model(context, 'stable-diffusion')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\512-base-ema.ckpt"
+load_model(context, "stable-diffusion")
 
 # generate the image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
 
 # save the image
-save_images(images, dir_path='.')
+save_images(images, dir_path=".")
 
 log.info("Generated images!")

--- a/examples/001-generate-model_file_on_disk.py
+++ b/examples/001-generate-model_file_on_disk.py
@@ -1,7 +1,7 @@
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
-from sdkit.utils import save_images, log
+from sdkit.models import load_model
+from sdkit.utils import log, save_images
 
 context = sdkit.Context()
 

--- a/examples/001-generate-model_file_on_disk.py
+++ b/examples/001-generate-model_file_on_disk.py
@@ -6,13 +6,19 @@ from sdkit.utils import save_images, log
 context = sdkit.Context()
 
 # set the path to the model file on the disk (.ckpt or .safetensors file)
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\512-base-ema.ckpt'
-load_model(context, 'stable-diffusion')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\512-base-ema.ckpt"
+load_model(context, "stable-diffusion")
 
 # generate the image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+)
 
 # save the image
-save_images(images, dir_path='.')
+save_images(images, dir_path=".")
 
 log.info("Generated images!")

--- a/examples/002-generate-download_known_model.py
+++ b/examples/002-generate-download_known_model.py
@@ -1,29 +1,21 @@
 import sdkit
+from sdkit.models import load_model, download_model, resolve_downloaded_model_path
 from sdkit.generate import generate_images
-from sdkit.models import download_model, load_model, resolve_downloaded_model_path
-from sdkit.utils import log, save_images
+from sdkit.utils import save_images, log
 
 context = sdkit.Context()
 
 # download the model (skips if already downloaded, resumes if downloaded partially)
-download_model(model_type="stable-diffusion", model_id="1.5-pruned-emaonly")
+download_model(model_type='stable-diffusion', model_id='1.5-pruned-emaonly')
 
 # set the path to the auto-downloaded model
-context.model_paths["stable-diffusion"] = resolve_downloaded_model_path(
-    context, "stable-diffusion", "1.5-pruned-emaonly"
-)
-load_model(context, "stable-diffusion")
+context.model_paths['stable-diffusion'] = resolve_downloaded_model_path(context, 'stable-diffusion', '1.5-pruned-emaonly')
+load_model(context, 'stable-diffusion')
 
 # generate the image
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-)
+images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
 
 # save the image
-save_images(images, dir_path="D:\\path\\to\\images\\directory")
+save_images(images, dir_path='D:\\path\\to\\images\\directory')
 
 log.info("Generated images!")

--- a/examples/002-generate-download_known_model.py
+++ b/examples/002-generate-download_known_model.py
@@ -1,7 +1,7 @@
 import sdkit
-from sdkit.models import load_model, download_model, resolve_downloaded_model_path
 from sdkit.generate import generate_images
-from sdkit.utils import save_images, log
+from sdkit.models import download_model, load_model, resolve_downloaded_model_path
+from sdkit.utils import log, save_images
 
 context = sdkit.Context()
 

--- a/examples/002-generate-download_known_model.py
+++ b/examples/002-generate-download_known_model.py
@@ -6,16 +6,18 @@ from sdkit.utils import log, save_images
 context = sdkit.Context()
 
 # download the model (skips if already downloaded, resumes if downloaded partially)
-download_model(model_type='stable-diffusion', model_id='1.5-pruned-emaonly')
+download_model(model_type="stable-diffusion", model_id="1.5-pruned-emaonly")
 
 # set the path to the auto-downloaded model
-context.model_paths['stable-diffusion'] = resolve_downloaded_model_path(context, 'stable-diffusion', '1.5-pruned-emaonly')
-load_model(context, 'stable-diffusion')
+context.model_paths["stable-diffusion"] = resolve_downloaded_model_path(
+    context, "stable-diffusion", "1.5-pruned-emaonly"
+)
+load_model(context, "stable-diffusion")
 
 # generate the image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
 
 # save the image
-save_images(images, dir_path='D:\\path\\to\\images\\directory')
+save_images(images, dir_path="D:\\path\\to\\images\\directory")
 
 log.info("Generated images!")

--- a/examples/002-generate-download_known_model.py
+++ b/examples/002-generate-download_known_model.py
@@ -6,16 +6,24 @@ from sdkit.utils import save_images, log
 context = sdkit.Context()
 
 # download the model (skips if already downloaded, resumes if downloaded partially)
-download_model(model_type='stable-diffusion', model_id='1.5-pruned-emaonly')
+download_model(model_type="stable-diffusion", model_id="1.5-pruned-emaonly")
 
 # set the path to the auto-downloaded model
-context.model_paths['stable-diffusion'] = resolve_downloaded_model_path(context, 'stable-diffusion', '1.5-pruned-emaonly')
-load_model(context, 'stable-diffusion')
+context.model_paths["stable-diffusion"] = resolve_downloaded_model_path(
+    context, "stable-diffusion", "1.5-pruned-emaonly"
+)
+load_model(context, "stable-diffusion")
 
 # generate the image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+)
 
 # save the image
-save_images(images, dir_path='D:\\path\\to\\images\\directory')
+save_images(images, dir_path="D:\\path\\to\\images\\directory")
 
 log.info("Generated images!")

--- a/examples/002b-generate-download_multiple_known_models.py
+++ b/examples/002b-generate-download_multiple_known_models.py
@@ -1,6 +1,7 @@
 from sdkit.models import download_models
 
-# download all three models (skips if already downloaded, resumes if downloaded partially)
+# download all three models (skips if already downloaded,
+# resumes if downloaded partially)
 download_models(
     models={
         "stable-diffusion": ["1.4", "1.5-pruned-emaonly"],

--- a/examples/002b-generate-download_multiple_known_models.py
+++ b/examples/002b-generate-download_multiple_known_models.py
@@ -1,7 +1,9 @@
 from sdkit.models import download_models
 
 # download all three models (skips if already downloaded, resumes if downloaded partially)
-download_models(models={
-    'stable-diffusion': ['1.4', '1.5-pruned-emaonly'],
-    'gfpgan': '1.3',
-})
+download_models(
+    models={
+        "stable-diffusion": ["1.4", "1.5-pruned-emaonly"],
+        "gfpgan": "1.3",
+    }
+)

--- a/examples/002b-generate-download_multiple_known_models.py
+++ b/examples/002b-generate-download_multiple_known_models.py
@@ -1,10 +1,7 @@
 from sdkit.models import download_models
 
-# download all three models (skips if already downloaded,
-# resumes if downloaded partially)
-download_models(
-    models={
-        "stable-diffusion": ["1.4", "1.5-pruned-emaonly"],
-        "gfpgan": "1.3",
-    }
-)
+# download all three models (skips if already downloaded, resumes if downloaded partially)
+download_models(models={
+    'stable-diffusion': ['1.4', '1.5-pruned-emaonly'],
+    'gfpgan': '1.3',
+})

--- a/examples/003-generate-custom_model.py
+++ b/examples/003-generate-custom_model.py
@@ -6,9 +6,7 @@ from sdkit.utils import log, save_images
 context = sdkit.Context()
 
 # set the path to the custom model file on the disk
-context.model_paths[
-    "stable-diffusion"
-] = "D:\\path\\to\\cmodelUpgradeStableD.safetensors"
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\cmodelUpgradeStableD.safetensors"
 context.model_configs["stable-diffusion"] = "D:\\path\\to\\Cmodelsafetensor.yaml"
 # the yaml config file is required if it's an unknown model to use.
 # it is not necessary for known models present in the models_db.

--- a/examples/003-generate-custom_model.py
+++ b/examples/003-generate-custom_model.py
@@ -1,28 +1,22 @@
 import sdkit
-from sdkit.generate import generate_images
 from sdkit.models import load_model
-from sdkit.utils import log, save_images
+from sdkit.generate import generate_images
+from sdkit.utils import save_images, log
 
 context = sdkit.Context()
 
 # set the path to the custom model file on the disk
-context.model_paths["stable-diffusion"] = "D:\\path\\to\\cmodelUpgradeStableD.safetensors"
-context.model_configs["stable-diffusion"] = "D:\\path\\to\\Cmodelsafetensor.yaml"
+context.model_paths['stable-diffusion'] = 'D:\\path\\to\\cmodelUpgradeStableD.safetensors'
+context.model_configs['stable-diffusion'] = 'D:\\path\\to\\Cmodelsafetensor.yaml'
 # the yaml config file is required if it's an unknown model to use.
 # it is not necessary for known models present in the models_db.
 
-load_model(context, "stable-diffusion")
+load_model(context, 'stable-diffusion')
 
 # generate the image
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-)
+images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
 
 # save the image
-save_images(images, dir_path="D:\\path\\to\\images\\directory")
+save_images(images, dir_path='D:\\path\\to\\images\\directory')
 
 log.info("Generated images!")

--- a/examples/003-generate-custom_model.py
+++ b/examples/003-generate-custom_model.py
@@ -1,7 +1,7 @@
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
-from sdkit.utils import save_images, log
+from sdkit.models import load_model
+from sdkit.utils import log, save_images
 
 context = sdkit.Context()
 

--- a/examples/003-generate-custom_model.py
+++ b/examples/003-generate-custom_model.py
@@ -6,17 +6,17 @@ from sdkit.utils import log, save_images
 context = sdkit.Context()
 
 # set the path to the custom model file on the disk
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\cmodelUpgradeStableD.safetensors'
-context.model_configs['stable-diffusion'] = 'D:\\path\\to\\Cmodelsafetensor.yaml'
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\cmodelUpgradeStableD.safetensors"
+context.model_configs["stable-diffusion"] = "D:\\path\\to\\Cmodelsafetensor.yaml"
 # the yaml config file is required if it's an unknown model to use.
 # it is not necessary for known models present in the models_db.
 
-load_model(context, 'stable-diffusion')
+load_model(context, "stable-diffusion")
 
 # generate the image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
 
 # save the image
-save_images(images, dir_path='D:\\path\\to\\images\\directory')
+save_images(images, dir_path="D:\\path\\to\\images\\directory")
 
 log.info("Generated images!")

--- a/examples/003-generate-custom_model.py
+++ b/examples/003-generate-custom_model.py
@@ -6,17 +6,25 @@ from sdkit.utils import save_images, log
 context = sdkit.Context()
 
 # set the path to the custom model file on the disk
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\cmodelUpgradeStableD.safetensors'
-context.model_configs['stable-diffusion'] = 'D:\\path\\to\\Cmodelsafetensor.yaml'
+context.model_paths[
+    "stable-diffusion"
+] = "D:\\path\\to\\cmodelUpgradeStableD.safetensors"
+context.model_configs["stable-diffusion"] = "D:\\path\\to\\Cmodelsafetensor.yaml"
 # the yaml config file is required if it's an unknown model to use.
 # it is not necessary for known models present in the models_db.
 
-load_model(context, 'stable-diffusion')
+load_model(context, "stable-diffusion")
 
 # generate the image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+)
 
 # save the image
-save_images(images, dir_path='D:\\path\\to\\images\\directory')
+save_images(images, dir_path="D:\\path\\to\\images\\directory")
 
 log.info("Generated images!")

--- a/examples/004-generate-custom_vae.py
+++ b/examples/004-generate-custom_vae.py
@@ -1,26 +1,20 @@
 import sdkit
-from sdkit.generate import generate_images
 from sdkit.models import load_model
-from sdkit.utils import log, save_images
+from sdkit.generate import generate_images
+from sdkit.utils import save_images, log
 
 context = sdkit.Context()
 
 # set the path to the model and VAE file on the disk
-context.model_paths["stable-diffusion"] = "D:\\path\\to\\model.ckpt"
-context.model_paths["vae"] = "D:\\path\\to\\vae.ckpt"
-load_model(context, "stable-diffusion")
-load_model(context, "vae")
+context.model_paths['stable-diffusion'] = 'D:\\path\\to\\model.ckpt'
+context.model_paths['vae'] = 'D:\\path\\to\\vae.ckpt'
+load_model(context, 'stable-diffusion')
+load_model(context, 'vae')
 
 # generate the image
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-)
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
 
 # save the image
-save_images(images, dir_path="D:\\path\\to\\images\\directory")
+save_images(images, dir_path='D:\\path\\to\\images\\directory')
 
-log.info("Generated images with a custom VAE!")
+log.info('Generated images with a custom VAE!')

--- a/examples/004-generate-custom_vae.py
+++ b/examples/004-generate-custom_vae.py
@@ -6,15 +6,21 @@ from sdkit.utils import save_images, log
 context = sdkit.Context()
 
 # set the path to the model and VAE file on the disk
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\model.ckpt'
-context.model_paths['vae'] = 'D:\\path\\to\\vae.ckpt'
-load_model(context, 'stable-diffusion')
-load_model(context, 'vae')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\model.ckpt"
+context.model_paths["vae"] = "D:\\path\\to\\vae.ckpt"
+load_model(context, "stable-diffusion")
+load_model(context, "vae")
 
 # generate the image
-images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+)
 
 # save the image
-save_images(images, dir_path='D:\\path\\to\\images\\directory')
+save_images(images, dir_path="D:\\path\\to\\images\\directory")
 
-log.info('Generated images with a custom VAE!')
+log.info("Generated images with a custom VAE!")

--- a/examples/004-generate-custom_vae.py
+++ b/examples/004-generate-custom_vae.py
@@ -1,7 +1,7 @@
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
-from sdkit.utils import save_images, log
+from sdkit.models import load_model
+from sdkit.utils import log, save_images
 
 context = sdkit.Context()
 

--- a/examples/004-generate-custom_vae.py
+++ b/examples/004-generate-custom_vae.py
@@ -6,15 +6,15 @@ from sdkit.utils import log, save_images
 context = sdkit.Context()
 
 # set the path to the model and VAE file on the disk
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\model.ckpt'
-context.model_paths['vae'] = 'D:\\path\\to\\vae.ckpt'
-load_model(context, 'stable-diffusion')
-load_model(context, 'vae')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\model.ckpt"
+context.model_paths["vae"] = "D:\\path\\to\\vae.ckpt"
+load_model(context, "stable-diffusion")
+load_model(context, "vae")
 
 # generate the image
 images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
 
 # save the image
-save_images(images, dir_path='D:\\path\\to\\images\\directory')
+save_images(images, dir_path="D:\\path\\to\\images\\directory")
 
-log.info('Generated images with a custom VAE!')
+log.info("Generated images with a custom VAE!")

--- a/examples/005-generate-custom_hypernetwork.py
+++ b/examples/005-generate-custom_hypernetwork.py
@@ -1,27 +1,20 @@
 import sdkit
-from sdkit.generate import generate_images
 from sdkit.models import load_model
-from sdkit.utils import log, save_images
+from sdkit.generate import generate_images
+from sdkit.utils import save_images, log
 
 context = sdkit.Context()
 
 # set the path to the model and hypernetwork file on the disk
-context.model_paths["stable-diffusion"] = "D:\\path\\to\\model.ckpt"
-context.model_paths["hypernetwork"] = "D:\\path\\to\\hypernetwork.pt"
-load_model(context, "stable-diffusion")
-load_model(context, "hypernetwork")
+context.model_paths['stable-diffusion'] = 'D:\\path\\to\\model.ckpt'
+context.model_paths['hypernetwork'] = 'D:\\path\\to\\hypernetwork.pt'
+load_model(context, 'stable-diffusion')
+load_model(context, 'hypernetwork')
 
 # generate the image, hypernetwork_strength at 0.3
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-    hypernetwork_strength=0.3,
-)
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512, hypernetwork_strength=0.3)
 
 # save the image
-save_images(images, dir_path="D:\\path\\to\\images\\directory")
+save_images(images, dir_path='D:\\path\\to\\images\\directory')
 
-log.info("Generated images with a custom VAE!")
+log.info('Generated images with a custom VAE!')

--- a/examples/005-generate-custom_hypernetwork.py
+++ b/examples/005-generate-custom_hypernetwork.py
@@ -6,15 +6,22 @@ from sdkit.utils import log, save_images
 context = sdkit.Context()
 
 # set the path to the model and hypernetwork file on the disk
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\model.ckpt'
-context.model_paths['hypernetwork'] = 'D:\\path\\to\\hypernetwork.pt'
-load_model(context, 'stable-diffusion')
-load_model(context, 'hypernetwork')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\model.ckpt"
+context.model_paths["hypernetwork"] = "D:\\path\\to\\hypernetwork.pt"
+load_model(context, "stable-diffusion")
+load_model(context, "hypernetwork")
 
 # generate the image, hypernetwork_strength at 0.3
-images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512, hypernetwork_strength=0.3)
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+    hypernetwork_strength=0.3,
+)
 
 # save the image
-save_images(images, dir_path='D:\\path\\to\\images\\directory')
+save_images(images, dir_path="D:\\path\\to\\images\\directory")
 
-log.info('Generated images with a custom VAE!')
+log.info("Generated images with a custom VAE!")

--- a/examples/005-generate-custom_hypernetwork.py
+++ b/examples/005-generate-custom_hypernetwork.py
@@ -6,15 +6,22 @@ from sdkit.utils import save_images, log
 context = sdkit.Context()
 
 # set the path to the model and hypernetwork file on the disk
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\model.ckpt'
-context.model_paths['hypernetwork'] = 'D:\\path\\to\\hypernetwork.pt'
-load_model(context, 'stable-diffusion')
-load_model(context, 'hypernetwork')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\model.ckpt"
+context.model_paths["hypernetwork"] = "D:\\path\\to\\hypernetwork.pt"
+load_model(context, "stable-diffusion")
+load_model(context, "hypernetwork")
 
 # generate the image, hypernetwork_strength at 0.3
-images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512, hypernetwork_strength=0.3)
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+    hypernetwork_strength=0.3,
+)
 
 # save the image
-save_images(images, dir_path='D:\\path\\to\\images\\directory')
+save_images(images, dir_path="D:\\path\\to\\images\\directory")
 
-log.info('Generated images with a custom VAE!')
+log.info("Generated images with a custom VAE!")

--- a/examples/005-generate-custom_hypernetwork.py
+++ b/examples/005-generate-custom_hypernetwork.py
@@ -1,7 +1,7 @@
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
-from sdkit.utils import save_images, log
+from sdkit.models import load_model
+from sdkit.utils import log, save_images
 
 context = sdkit.Context()
 

--- a/examples/006-generate-change_models.py
+++ b/examples/006-generate-change_models.py
@@ -3,8 +3,8 @@
 # the unused hypernetwork and modelA.ckpt will be unloaded from memory automatically.
 
 import sdkit
-from sdkit.models import load_model, unload_model
 from sdkit.generate import generate_images
+from sdkit.models import load_model, unload_model
 from sdkit.utils import save_images
 
 context = sdkit.Context()

--- a/examples/006-generate-change_models.py
+++ b/examples/006-generate-change_models.py
@@ -10,21 +10,28 @@ from sdkit.utils import save_images
 context = sdkit.Context()
 
 # first image with modelA.ckpt, with hypernetwork
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\modelA.ckpt'
-context.model_paths['hypernetwork'] = 'D:\\path\\to\\hypernetwork.pt'
-load_model(context, 'stable-diffusion')
-load_model(context, 'hypernetwork')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\modelA.ckpt"
+context.model_paths["hypernetwork"] = "D:\\path\\to\\hypernetwork.pt"
+load_model(context, "stable-diffusion")
+load_model(context, "hypernetwork")
 
-images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512, hypernetwork_strength=0.3)
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+    hypernetwork_strength=0.3,
+)
 
-save_images(images, dir_path='D:\\path\\to\\images\\directory', file_name='image_modelA_with_hypernetwork')
+save_images(images, dir_path="D:\\path\\to\\images\\directory", file_name="image_modelA_with_hypernetwork")
 
 # second image with modelB.ckpt, without hypernetwork
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\modelB.ckpt'
-context.model_paths['hypernetwork'] = None
-load_model(context, 'stable-diffusion')
-unload_model(context, 'hypernetwork')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\modelB.ckpt"
+context.model_paths["hypernetwork"] = None
+load_model(context, "stable-diffusion")
+unload_model(context, "hypernetwork")
 
 images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
 
-save_images(images, dir_path='D:\\path\\to\\images\\directory', file_name='image_modelB_without_hypernetwork')
+save_images(images, dir_path="D:\\path\\to\\images\\directory", file_name="image_modelB_without_hypernetwork")

--- a/examples/006-generate-change_models.py
+++ b/examples/006-generate-change_models.py
@@ -3,49 +3,28 @@
 # the unused hypernetwork and modelA.ckpt will be unloaded from memory automatically.
 
 import sdkit
-from sdkit.generate import generate_images
 from sdkit.models import load_model, unload_model
+from sdkit.generate import generate_images
 from sdkit.utils import save_images
 
 context = sdkit.Context()
 
 # first image with modelA.ckpt, with hypernetwork
-context.model_paths["stable-diffusion"] = "D:\\path\\to\\modelA.ckpt"
-context.model_paths["hypernetwork"] = "D:\\path\\to\\hypernetwork.pt"
-load_model(context, "stable-diffusion")
-load_model(context, "hypernetwork")
+context.model_paths['stable-diffusion'] = 'D:\\path\\to\\modelA.ckpt'
+context.model_paths['hypernetwork'] = 'D:\\path\\to\\hypernetwork.pt'
+load_model(context, 'stable-diffusion')
+load_model(context, 'hypernetwork')
 
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-    hypernetwork_strength=0.3,
-)
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512, hypernetwork_strength=0.3)
 
-save_images(
-    images,
-    dir_path="D:\\path\\to\\images\\directory",
-    file_name="image_modelA_with_hypernetwork",
-)
+save_images(images, dir_path='D:\\path\\to\\images\\directory', file_name='image_modelA_with_hypernetwork')
 
 # second image with modelB.ckpt, without hypernetwork
-context.model_paths["stable-diffusion"] = "D:\\path\\to\\modelB.ckpt"
-context.model_paths["hypernetwork"] = None
-load_model(context, "stable-diffusion")
-unload_model(context, "hypernetwork")
+context.model_paths['stable-diffusion'] = 'D:\\path\\to\\modelB.ckpt'
+context.model_paths['hypernetwork'] = None
+load_model(context, 'stable-diffusion')
+unload_model(context, 'hypernetwork')
 
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-)
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
 
-save_images(
-    images,
-    dir_path="D:\\path\\to\\images\\directory",
-    file_name="image_modelB_without_hypernetwork",
-)
+save_images(images, dir_path='D:\\path\\to\\images\\directory', file_name='image_modelB_without_hypernetwork')

--- a/examples/006-generate-change_models.py
+++ b/examples/006-generate-change_models.py
@@ -10,21 +10,42 @@ from sdkit.utils import save_images
 context = sdkit.Context()
 
 # first image with modelA.ckpt, with hypernetwork
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\modelA.ckpt'
-context.model_paths['hypernetwork'] = 'D:\\path\\to\\hypernetwork.pt'
-load_model(context, 'stable-diffusion')
-load_model(context, 'hypernetwork')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\modelA.ckpt"
+context.model_paths["hypernetwork"] = "D:\\path\\to\\hypernetwork.pt"
+load_model(context, "stable-diffusion")
+load_model(context, "hypernetwork")
 
-images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512, hypernetwork_strength=0.3)
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+    hypernetwork_strength=0.3,
+)
 
-save_images(images, dir_path='D:\\path\\to\\images\\directory', file_name='image_modelA_with_hypernetwork')
+save_images(
+    images,
+    dir_path="D:\\path\\to\\images\\directory",
+    file_name="image_modelA_with_hypernetwork",
+)
 
 # second image with modelB.ckpt, without hypernetwork
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\modelB.ckpt'
-context.model_paths['hypernetwork'] = None
-load_model(context, 'stable-diffusion')
-unload_model(context, 'hypernetwork')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\modelB.ckpt"
+context.model_paths["hypernetwork"] = None
+load_model(context, "stable-diffusion")
+unload_model(context, "hypernetwork")
 
-images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+)
 
-save_images(images, dir_path='D:\\path\\to\\images\\directory', file_name='image_modelB_without_hypernetwork')
+save_images(
+    images,
+    dir_path="D:\\path\\to\\images\\directory",
+    file_name="image_modelB_without_hypernetwork",
+)

--- a/examples/007-generate-and-filter.py
+++ b/examples/007-generate-and-filter.py
@@ -1,6 +1,6 @@
 import sdkit
-from sdkit.generate import generate_images
 from sdkit.filter import apply_filters
+from sdkit.generate import generate_images
 from sdkit.utils import save_images
 
 context = sdkit.Context()

--- a/examples/007-generate-and-filter.py
+++ b/examples/007-generate-and-filter.py
@@ -1,6 +1,7 @@
 import sdkit
 from sdkit.filter import apply_filters
 from sdkit.generate import generate_images
+from sdkit.models import load_model
 from sdkit.utils import save_images
 
 context = sdkit.Context()

--- a/examples/007-generate-and-filter.py
+++ b/examples/007-generate-and-filter.py
@@ -2,6 +2,8 @@ import sdkit
 from sdkit.filter import apply_filters
 from sdkit.generate import generate_images
 from sdkit.utils import save_images
+from sdkit.models import load_model
+
 
 context = sdkit.Context()
 

--- a/examples/007-generate-and-filter.py
+++ b/examples/007-generate-and-filter.py
@@ -6,16 +6,27 @@ from sdkit.utils import save_images
 context = sdkit.Context()
 
 # setup model paths
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\modelA.ckpt'
-context.model_paths['gfpgan'] = 'C:\\path\\to\\gfpgan-1.3.pth'
-load_model(context, 'stable-diffusion')
-load_model(context, 'gfpgan')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\modelA.ckpt"
+context.model_paths["gfpgan"] = "C:\\path\\to\\gfpgan-1.3.pth"
+load_model(context, "stable-diffusion")
+load_model(context, "gfpgan")
 
 # generate image
-images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512, hypernetwork_strength=0.3)
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+    hypernetwork_strength=0.3,
+)
 
 # apply filter
-images_face_fixed = apply_filters(context, filters='gfpgan', images=images)
+images_face_fixed = apply_filters(context, filters="gfpgan", images=images)
 
 # save images
-save_images(images_face_fixed, dir_path='D:\\path\\to\\images\\directory', file_name='image_with_face_fix')
+save_images(
+    images_face_fixed,
+    dir_path="D:\\path\\to\\images\\directory",
+    file_name="image_with_face_fix",
+)

--- a/examples/007-generate-and-filter.py
+++ b/examples/007-generate-and-filter.py
@@ -1,33 +1,21 @@
 import sdkit
-from sdkit.filter import apply_filters
 from sdkit.generate import generate_images
-from sdkit.models import load_model
+from sdkit.filter import apply_filters
 from sdkit.utils import save_images
 
 context = sdkit.Context()
 
 # setup model paths
-context.model_paths["stable-diffusion"] = "D:\\path\\to\\modelA.ckpt"
-context.model_paths["gfpgan"] = "C:\\path\\to\\gfpgan-1.3.pth"
-load_model(context, "stable-diffusion")
-load_model(context, "gfpgan")
+context.model_paths['stable-diffusion'] = 'D:\\path\\to\\modelA.ckpt'
+context.model_paths['gfpgan'] = 'C:\\path\\to\\gfpgan-1.3.pth'
+load_model(context, 'stable-diffusion')
+load_model(context, 'gfpgan')
 
 # generate image
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-    hypernetwork_strength=0.3,
-)
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512, hypernetwork_strength=0.3)
 
 # apply filter
-images_face_fixed = apply_filters(context, filters="gfpgan", images=images)
+images_face_fixed = apply_filters(context, filters='gfpgan', images=images)
 
 # save images
-save_images(
-    images_face_fixed,
-    dir_path="D:\\path\\to\\images\\directory",
-    file_name="image_with_face_fix",
-)
+save_images(images_face_fixed, dir_path='D:\\path\\to\\images\\directory', file_name='image_with_face_fix')

--- a/examples/007-generate-and-filter.py
+++ b/examples/007-generate-and-filter.py
@@ -1,9 +1,8 @@
 import sdkit
 from sdkit.filter import apply_filters
 from sdkit.generate import generate_images
-from sdkit.utils import save_images
 from sdkit.models import load_model
-
+from sdkit.utils import save_images
 
 context = sdkit.Context()
 

--- a/examples/007-generate-and-filter.py
+++ b/examples/007-generate-and-filter.py
@@ -6,16 +6,23 @@ from sdkit.utils import save_images
 context = sdkit.Context()
 
 # setup model paths
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\modelA.ckpt'
-context.model_paths['gfpgan'] = 'C:\\path\\to\\gfpgan-1.3.pth'
-load_model(context, 'stable-diffusion')
-load_model(context, 'gfpgan')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\modelA.ckpt"
+context.model_paths["gfpgan"] = "C:\\path\\to\\gfpgan-1.3.pth"
+load_model(context, "stable-diffusion")
+load_model(context, "gfpgan")
 
 # generate image
-images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512, hypernetwork_strength=0.3)
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+    hypernetwork_strength=0.3,
+)
 
 # apply filter
-images_face_fixed = apply_filters(context, filters='gfpgan', images=images)
+images_face_fixed = apply_filters(context, filters="gfpgan", images=images)
 
 # save images
-save_images(images_face_fixed, dir_path='D:\\path\\to\\images\\directory', file_name='image_with_face_fix')
+save_images(images_face_fixed, dir_path="D:\\path\\to\\images\\directory", file_name="image_with_face_fix")

--- a/examples/100-filter-fix_faces.py
+++ b/examples/100-filter-fix_faces.py
@@ -1,7 +1,8 @@
-import sdkit
-from sdkit.models import load_model
-from sdkit.filter import apply_filters
 from PIL import Image
+
+import sdkit
+from sdkit.filter import apply_filters
+from sdkit.models import load_model
 
 context = sdkit.Context()
 image = Image.open("photo of a man.jpg")

--- a/examples/100-filter-fix_faces.py
+++ b/examples/100-filter-fix_faces.py
@@ -1,18 +1,17 @@
+import sdkit
+from sdkit.models import load_model
+from sdkit.filter import apply_filters
 from PIL import Image
 
-import sdkit
-from sdkit.filter import apply_filters
-from sdkit.models import load_model
-
 context = sdkit.Context()
-image = Image.open("photo of a man.jpg")
+image = Image.open('photo of a man.jpg')
 
 # set the path to the model file on the disk
-context.model_paths["gfpgan"] = "C:\\path\\to\\gfpgan-1.3.pth"
-load_model(context, "gfpgan")
+context.model_paths['gfpgan'] = 'C:\\path\\to\\gfpgan-1.3.pth'
+load_model(context, 'gfpgan')
 
 # apply the filter
-image_face_fixed = apply_filters(context, "gfpgan", image)
+image_face_fixed = apply_filters(context, 'gfpgan', image)
 
 # save the filtered image
-image_face_fixed.save("man_face_fixed.jpg")
+image_face_fixed.save('man_face_fixed.jpg')

--- a/examples/100-filter-fix_faces.py
+++ b/examples/100-filter-fix_faces.py
@@ -1,7 +1,8 @@
-import sdkit
-from sdkit.models import load_model
-from sdkit.filter import apply_filters
 from PIL import Image
+
+import sdkit
+from sdkit.filter import apply_filters
+from sdkit.models import load_model
 
 context = sdkit.Context()
 image = Image.open('photo of a man.jpg')

--- a/examples/100-filter-fix_faces.py
+++ b/examples/100-filter-fix_faces.py
@@ -5,14 +5,14 @@ from sdkit.filter import apply_filters
 from sdkit.models import load_model
 
 context = sdkit.Context()
-image = Image.open('photo of a man.jpg')
+image = Image.open("photo of a man.jpg")
 
 # set the path to the model file on the disk
-context.model_paths['gfpgan'] = 'C:\\path\\to\\gfpgan-1.3.pth'
-load_model(context, 'gfpgan')
+context.model_paths["gfpgan"] = "C:\\path\\to\\gfpgan-1.3.pth"
+load_model(context, "gfpgan")
 
 # apply the filter
-image_face_fixed = apply_filters(context, 'gfpgan', image)
+image_face_fixed = apply_filters(context, "gfpgan", image)
 
 # save the filtered image
-image_face_fixed.save('man_face_fixed.jpg')
+image_face_fixed.save("man_face_fixed.jpg")

--- a/examples/100-filter-fix_faces.py
+++ b/examples/100-filter-fix_faces.py
@@ -4,14 +4,14 @@ from sdkit.filter import apply_filters
 from PIL import Image
 
 context = sdkit.Context()
-image = Image.open('photo of a man.jpg')
+image = Image.open("photo of a man.jpg")
 
 # set the path to the model file on the disk
-context.model_paths['gfpgan'] = 'C:\\path\\to\\gfpgan-1.3.pth'
-load_model(context, 'gfpgan')
+context.model_paths["gfpgan"] = "C:\\path\\to\\gfpgan-1.3.pth"
+load_model(context, "gfpgan")
 
 # apply the filter
-image_face_fixed = apply_filters(context, 'gfpgan', image)
+image_face_fixed = apply_filters(context, "gfpgan", image)
 
 # save the filtered image
-image_face_fixed.save('man_face_fixed.jpg')
+image_face_fixed.save("man_face_fixed.jpg")

--- a/examples/101-filter-fix_faces_download_known_model.py
+++ b/examples/101-filter-fix_faces_download_known_model.py
@@ -1,21 +1,20 @@
+import sdkit
+from sdkit.models import download_model, resolve_downloaded_model_path, load_model
+from sdkit.filter import apply_filters
 from PIL import Image
 
-import sdkit
-from sdkit.filter import apply_filters
-from sdkit.models import download_model, load_model, resolve_downloaded_model_path
-
 context = sdkit.Context()
-image = Image.open("photo of a man.jpg")
+image = Image.open('photo of a man.jpg')
 
 # download the model (skips if already downloaded, resumes if downloaded partially)
-download_model(model_type="gfpgan", model_id="1.3")
+download_model(model_type='gfpgan', model_id='1.3')
 
 # set the path to the auto-downloaded model
-context.model_paths["gfpgan"] = resolve_downloaded_model_path(context, "gfpgan", "1.3")
-load_model(context, "gfpgan")
+context.model_paths['gfpgan'] = resolve_downloaded_model_path(context, 'gfpgan', '1.3')
+load_model(context, 'gfpgan')
 
 # apply the filter
-image_face_fixed = apply_filters(context, "gfpgan", image)
+image_face_fixed = apply_filters(context, 'gfpgan', image)
 
 # save the filtered image
-image_face_fixed.save("man_face_fixed.jpg")
+image_face_fixed.save('man_face_fixed.jpg')

--- a/examples/101-filter-fix_faces_download_known_model.py
+++ b/examples/101-filter-fix_faces_download_known_model.py
@@ -5,17 +5,17 @@ from sdkit.filter import apply_filters
 from sdkit.models import download_model, load_model, resolve_downloaded_model_path
 
 context = sdkit.Context()
-image = Image.open('photo of a man.jpg')
+image = Image.open("photo of a man.jpg")
 
 # download the model (skips if already downloaded, resumes if downloaded partially)
-download_model(model_type='gfpgan', model_id='1.3')
+download_model(model_type="gfpgan", model_id="1.3")
 
 # set the path to the auto-downloaded model
-context.model_paths['gfpgan'] = resolve_downloaded_model_path(context, 'gfpgan', '1.3')
-load_model(context, 'gfpgan')
+context.model_paths["gfpgan"] = resolve_downloaded_model_path(context, "gfpgan", "1.3")
+load_model(context, "gfpgan")
 
 # apply the filter
-image_face_fixed = apply_filters(context, 'gfpgan', image)
+image_face_fixed = apply_filters(context, "gfpgan", image)
 
 # save the filtered image
-image_face_fixed.save('man_face_fixed.jpg')
+image_face_fixed.save("man_face_fixed.jpg")

--- a/examples/101-filter-fix_faces_download_known_model.py
+++ b/examples/101-filter-fix_faces_download_known_model.py
@@ -1,7 +1,8 @@
-import sdkit
-from sdkit.models import download_model, resolve_downloaded_model_path, load_model
-from sdkit.filter import apply_filters
 from PIL import Image
+
+import sdkit
+from sdkit.filter import apply_filters
+from sdkit.models import download_model, load_model, resolve_downloaded_model_path
 
 context = sdkit.Context()
 image = Image.open('photo of a man.jpg')

--- a/examples/101-filter-fix_faces_download_known_model.py
+++ b/examples/101-filter-fix_faces_download_known_model.py
@@ -1,7 +1,8 @@
-import sdkit
-from sdkit.models import download_model, resolve_downloaded_model_path, load_model
-from sdkit.filter import apply_filters
 from PIL import Image
+
+import sdkit
+from sdkit.filter import apply_filters
+from sdkit.models import download_model, load_model, resolve_downloaded_model_path
 
 context = sdkit.Context()
 image = Image.open("photo of a man.jpg")

--- a/examples/101-filter-fix_faces_download_known_model.py
+++ b/examples/101-filter-fix_faces_download_known_model.py
@@ -4,17 +4,17 @@ from sdkit.filter import apply_filters
 from PIL import Image
 
 context = sdkit.Context()
-image = Image.open('photo of a man.jpg')
+image = Image.open("photo of a man.jpg")
 
 # download the model (skips if already downloaded, resumes if downloaded partially)
-download_model(model_type='gfpgan', model_id='1.3')
+download_model(model_type="gfpgan", model_id="1.3")
 
 # set the path to the auto-downloaded model
-context.model_paths['gfpgan'] = resolve_downloaded_model_path(context, 'gfpgan', '1.3')
-load_model(context, 'gfpgan')
+context.model_paths["gfpgan"] = resolve_downloaded_model_path(context, "gfpgan", "1.3")
+load_model(context, "gfpgan")
 
 # apply the filter
-image_face_fixed = apply_filters(context, 'gfpgan', image)
+image_face_fixed = apply_filters(context, "gfpgan", image)
 
 # save the filtered image
-image_face_fixed.save('man_face_fixed.jpg')
+image_face_fixed.save("man_face_fixed.jpg")

--- a/examples/102-filter-upscale.py
+++ b/examples/102-filter-upscale.py
@@ -1,7 +1,8 @@
-import sdkit
-from sdkit.models import load_model
-from sdkit.filter import apply_filters
 from PIL import Image
+
+import sdkit
+from sdkit.filter import apply_filters
+from sdkit.models import load_model
 
 context = sdkit.Context()
 image = Image.open("photo of a man.jpg")

--- a/examples/102-filter-upscale.py
+++ b/examples/102-filter-upscale.py
@@ -1,19 +1,18 @@
+import sdkit
+from sdkit.models import load_model
+from sdkit.filter import apply_filters
 from PIL import Image
 
-import sdkit
-from sdkit.filter import apply_filters
-from sdkit.models import load_model
-
 context = sdkit.Context()
-image = Image.open("photo of a man.jpg")
+image = Image.open('photo of a man.jpg')
 
 # set the path to the model file on the disk
-context.model_paths["realesrgan"] = "C:\\path\\to\\RealESRGAN_x4plus.pth"
-load_model(context, "realesrgan")
+context.model_paths['realesrgan'] = 'C:\\path\\to\\RealESRGAN_x4plus.pth'
+load_model(context, 'realesrgan')
 
 # apply the filter
-scale = 4  # or 2
-image_upscaled = apply_filters(context, "realesrgan", image, scale=scale)
+scale = 4 # or 2
+image_upscaled = apply_filters(context, 'realesrgan', image, scale=scale)
 
 # save the filtered image
-image_upscaled.save("man_upscaled.jpg")
+image_upscaled.save('man_upscaled.jpg')

--- a/examples/102-filter-upscale.py
+++ b/examples/102-filter-upscale.py
@@ -1,7 +1,8 @@
-import sdkit
-from sdkit.models import load_model
-from sdkit.filter import apply_filters
 from PIL import Image
+
+import sdkit
+from sdkit.filter import apply_filters
+from sdkit.models import load_model
 
 context = sdkit.Context()
 image = Image.open('photo of a man.jpg')

--- a/examples/102-filter-upscale.py
+++ b/examples/102-filter-upscale.py
@@ -5,15 +5,15 @@ from sdkit.filter import apply_filters
 from sdkit.models import load_model
 
 context = sdkit.Context()
-image = Image.open('photo of a man.jpg')
+image = Image.open("photo of a man.jpg")
 
 # set the path to the model file on the disk
-context.model_paths['realesrgan'] = 'C:\\path\\to\\RealESRGAN_x4plus.pth'
-load_model(context, 'realesrgan')
+context.model_paths["realesrgan"] = "C:\\path\\to\\RealESRGAN_x4plus.pth"
+load_model(context, "realesrgan")
 
 # apply the filter
-scale = 4 # or 2
-image_upscaled = apply_filters(context, 'realesrgan', image, scale=scale)
+scale = 4  # or 2
+image_upscaled = apply_filters(context, "realesrgan", image, scale=scale)
 
 # save the filtered image
-image_upscaled.save('man_upscaled.jpg')
+image_upscaled.save("man_upscaled.jpg")

--- a/examples/102-filter-upscale.py
+++ b/examples/102-filter-upscale.py
@@ -4,15 +4,15 @@ from sdkit.filter import apply_filters
 from PIL import Image
 
 context = sdkit.Context()
-image = Image.open('photo of a man.jpg')
+image = Image.open("photo of a man.jpg")
 
 # set the path to the model file on the disk
-context.model_paths['realesrgan'] = 'C:\\path\\to\\RealESRGAN_x4plus.pth'
-load_model(context, 'realesrgan')
+context.model_paths["realesrgan"] = "C:\\path\\to\\RealESRGAN_x4plus.pth"
+load_model(context, "realesrgan")
 
 # apply the filter
-scale = 4 # or 2
-image_upscaled = apply_filters(context, 'realesrgan', image, scale=scale)
+scale = 4  # or 2
+image_upscaled = apply_filters(context, "realesrgan", image, scale=scale)
 
 # save the filtered image
-image_upscaled.save('man_upscaled.jpg')
+image_upscaled.save("man_upscaled.jpg")

--- a/examples/103-filter-multiple.py
+++ b/examples/103-filter-multiple.py
@@ -1,7 +1,8 @@
-import sdkit
-from sdkit.models import load_model
-from sdkit.filter import apply_filters
 from PIL import Image
+
+import sdkit
+from sdkit.filter import apply_filters
+from sdkit.models import load_model
 
 context = sdkit.Context()
 image = Image.open("photo of a man.jpg")

--- a/examples/103-filter-multiple.py
+++ b/examples/103-filter-multiple.py
@@ -4,22 +4,22 @@ from sdkit.filter import apply_filters
 from PIL import Image
 
 context = sdkit.Context()
-image = Image.open('photo of a man.jpg')
+image = Image.open("photo of a man.jpg")
 
 # set the path to the model files on the disk
 context.model_paths = {
-    'gfpgan': 'C:\\path\\to\\gfpgan-1.3.pth',
-    'realesrgan': 'C:\\path\\to\\realesrgan.pth',
+    "gfpgan": "C:\\path\\to\\gfpgan-1.3.pth",
+    "realesrgan": "C:\\path\\to\\realesrgan.pth",
 }
-load_model(context, 'gfpgan')
-load_model(context, 'realesrgan')
+load_model(context, "gfpgan")
+load_model(context, "realesrgan")
 
 # apply the filters
-image_face_fixed = apply_filters(context, 'gfpgan', image)
-image_scaled_up = apply_filters(context, 'realesrgan', image)
-image_face_fixed_and_scaled_up = apply_filters(context, ['gfpgan', 'realesrgan'], image)
+image_face_fixed = apply_filters(context, "gfpgan", image)
+image_scaled_up = apply_filters(context, "realesrgan", image)
+image_face_fixed_and_scaled_up = apply_filters(context, ["gfpgan", "realesrgan"], image)
 
 # save the filtered images
-image_face_fixed.save('man_face_fixed.jpg')
-image_scaled_up.save('man_scaled_up.jpg')
-image_face_fixed_and_scaled_up.save('man_face_fixed_and_scaled_up.jpg')
+image_face_fixed.save("man_face_fixed.jpg")
+image_scaled_up.save("man_scaled_up.jpg")
+image_face_fixed_and_scaled_up.save("man_face_fixed_and_scaled_up.jpg")

--- a/examples/103-filter-multiple.py
+++ b/examples/103-filter-multiple.py
@@ -1,26 +1,25 @@
+import sdkit
+from sdkit.models import load_model
+from sdkit.filter import apply_filters
 from PIL import Image
 
-import sdkit
-from sdkit.filter import apply_filters
-from sdkit.models import load_model
-
 context = sdkit.Context()
-image = Image.open("photo of a man.jpg")
+image = Image.open('photo of a man.jpg')
 
 # set the path to the model files on the disk
 context.model_paths = {
-    "gfpgan": "C:\\path\\to\\gfpgan-1.3.pth",
-    "realesrgan": "C:\\path\\to\\realesrgan.pth",
+    'gfpgan': 'C:\\path\\to\\gfpgan-1.3.pth',
+    'realesrgan': 'C:\\path\\to\\realesrgan.pth',
 }
-load_model(context, "gfpgan")
-load_model(context, "realesrgan")
+load_model(context, 'gfpgan')
+load_model(context, 'realesrgan')
 
 # apply the filters
-image_face_fixed = apply_filters(context, "gfpgan", image)
-image_scaled_up = apply_filters(context, "realesrgan", image)
-image_face_fixed_and_scaled_up = apply_filters(context, ["gfpgan", "realesrgan"], image)
+image_face_fixed = apply_filters(context, 'gfpgan', image)
+image_scaled_up = apply_filters(context, 'realesrgan', image)
+image_face_fixed_and_scaled_up = apply_filters(context, ['gfpgan', 'realesrgan'], image)
 
 # save the filtered images
-image_face_fixed.save("man_face_fixed.jpg")
-image_scaled_up.save("man_scaled_up.jpg")
-image_face_fixed_and_scaled_up.save("man_face_fixed_and_scaled_up.jpg")
+image_face_fixed.save('man_face_fixed.jpg')
+image_scaled_up.save('man_scaled_up.jpg')
+image_face_fixed_and_scaled_up.save('man_face_fixed_and_scaled_up.jpg')

--- a/examples/103-filter-multiple.py
+++ b/examples/103-filter-multiple.py
@@ -1,7 +1,8 @@
-import sdkit
-from sdkit.models import load_model
-from sdkit.filter import apply_filters
 from PIL import Image
+
+import sdkit
+from sdkit.filter import apply_filters
+from sdkit.models import load_model
 
 context = sdkit.Context()
 image = Image.open('photo of a man.jpg')

--- a/examples/103-filter-multiple.py
+++ b/examples/103-filter-multiple.py
@@ -5,22 +5,22 @@ from sdkit.filter import apply_filters
 from sdkit.models import load_model
 
 context = sdkit.Context()
-image = Image.open('photo of a man.jpg')
+image = Image.open("photo of a man.jpg")
 
 # set the path to the model files on the disk
 context.model_paths = {
-    'gfpgan': 'C:\\path\\to\\gfpgan-1.3.pth',
-    'realesrgan': 'C:\\path\\to\\realesrgan.pth',
+    "gfpgan": "C:\\path\\to\\gfpgan-1.3.pth",
+    "realesrgan": "C:\\path\\to\\realesrgan.pth",
 }
-load_model(context, 'gfpgan')
-load_model(context, 'realesrgan')
+load_model(context, "gfpgan")
+load_model(context, "realesrgan")
 
 # apply the filters
-image_face_fixed = apply_filters(context, 'gfpgan', image)
-image_scaled_up = apply_filters(context, 'realesrgan', image)
-image_face_fixed_and_scaled_up = apply_filters(context, ['gfpgan', 'realesrgan'], image)
+image_face_fixed = apply_filters(context, "gfpgan", image)
+image_scaled_up = apply_filters(context, "realesrgan", image)
+image_face_fixed_and_scaled_up = apply_filters(context, ["gfpgan", "realesrgan"], image)
 
 # save the filtered images
-image_face_fixed.save('man_face_fixed.jpg')
-image_scaled_up.save('man_scaled_up.jpg')
-image_face_fixed_and_scaled_up.save('man_face_fixed_and_scaled_up.jpg')
+image_face_fixed.save("man_face_fixed.jpg")
+image_scaled_up.save("man_scaled_up.jpg")
+image_face_fixed_and_scaled_up.save("man_face_fixed_and_scaled_up.jpg")

--- a/examples/200-train-merge_models.py
+++ b/examples/200-train-merge_models.py
@@ -1,9 +1,9 @@
 from sdkit.train import merge_models
 
 merge_models(
-    model0_path="D:\\path\\to\\model_a.ckpt",
-    model1_path="D:\\path\\to\\model_b.ckpt",
+    model0_path='D:\\path\\to\\model_a.ckpt',
+    model1_path='D:\\path\\to\\model_b.ckpt',
     ratio=0.3,
-    out_path="D:\\path\\to\\merged_model.safetensors",
-    use_fp16=True,
+    out_path='D:\\path\\to\\merged_model.safetensors',
+    use_fp16=True
 )

--- a/examples/200-train-merge_models.py
+++ b/examples/200-train-merge_models.py
@@ -1,9 +1,9 @@
 from sdkit.train import merge_models
 
 merge_models(
-    model0_path='D:\\path\\to\\model_a.ckpt',
-    model1_path='D:\\path\\to\\model_b.ckpt',
+    model0_path="D:\\path\\to\\model_a.ckpt",
+    model1_path="D:\\path\\to\\model_b.ckpt",
     ratio=0.3,
-    out_path='D:\\path\\to\\merged_model.safetensors',
-    use_fp16=True
+    out_path="D:\\path\\to\\merged_model.safetensors",
+    use_fp16=True,
 )

--- a/examples/300-device-low-vram.py
+++ b/examples/300-device-low-vram.py
@@ -1,6 +1,6 @@
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
+from sdkit.models import load_model
 
 # this example will generate an image, using 3 different VRAM configurations.
 

--- a/examples/300-device-low-vram.py
+++ b/examples/300-device-low-vram.py
@@ -22,9 +22,7 @@ images[0].save("image1.jpg")
 
 # TEST 2 - no VRAM optimizations (maximum VRAM usage, fastest performance)
 context.vram_usage_level = "high"
-load_model(
-    context, "stable-diffusion"
-)  # reload the model, to apply the change to VRAM optimization
+load_model(context, "stable-diffusion")  # reload the model, to apply the change to VRAM optimization
 
 images = generate_images(
     context,
@@ -38,9 +36,7 @@ images[0].save("image2.jpg")
 
 # TEST 3 - lowest VRAM usage, slowest performance (for GPUs with less than 4gb of VRAM)
 context.vram_usage_level = "low"
-load_model(
-    context, "stable-diffusion"
-)  # reload the model, to apply the change to VRAM optimization
+load_model(context, "stable-diffusion")  # reload the model, to apply the change to VRAM optimization
 
 images = generate_images(
     context,

--- a/examples/300-device-low-vram.py
+++ b/examples/300-device-low-vram.py
@@ -8,7 +8,8 @@ context = sdkit.Context()
 context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
 load_model(context, "stable-diffusion")
 
-# TEST 1 - default (balanced) VRAM optimizations (much lower VRAM usage, performance is nearly as fast as max)
+# TEST 1 - default (balanced) VRAM optimizations (much lower VRAM usage,
+# performance is nearly as fast as max)
 images = generate_images(
     context,
     prompt="Photograph of an astronaut riding a horse",

--- a/examples/300-device-low-vram.py
+++ b/examples/300-device-low-vram.py
@@ -5,25 +5,25 @@ from sdkit.models import load_model
 # this example will generate an image, using 3 different VRAM configurations.
 
 context = sdkit.Context()
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
-load_model(context, 'stable-diffusion')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
+load_model(context, "stable-diffusion")
 
 # TEST 1 - default (balanced) VRAM optimizations (much lower VRAM usage, performance is nearly as fast as max)
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save('image1.jpg')
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
+images[0].save("image1.jpg")
 
 
 # TEST 2 - no VRAM optimizations (maximum VRAM usage, fastest performance)
-context.vram_usage_level = 'high'
-load_model(context, 'stable-diffusion') # reload the model, to apply the change to VRAM optimization
+context.vram_usage_level = "high"
+load_model(context, "stable-diffusion")  # reload the model, to apply the change to VRAM optimization
 
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save('image2.jpg')
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
+images[0].save("image2.jpg")
 
 
 # TEST 3 - lowest VRAM usage, slowest performance (for GPUs with less than 4gb of VRAM)
-context.vram_usage_level = 'low'
-load_model(context, 'stable-diffusion') # reload the model, to apply the change to VRAM optimization
+context.vram_usage_level = "low"
+load_model(context, "stable-diffusion")  # reload the model, to apply the change to VRAM optimization
 
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save('image3.jpg')
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
+images[0].save("image3.jpg")

--- a/examples/300-device-low-vram.py
+++ b/examples/300-device-low-vram.py
@@ -5,25 +5,47 @@ from sdkit.generate import generate_images
 # this example will generate an image, using 3 different VRAM configurations.
 
 context = sdkit.Context()
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
-load_model(context, 'stable-diffusion')
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
+load_model(context, "stable-diffusion")
 
 # TEST 1 - default (balanced) VRAM optimizations (much lower VRAM usage, performance is nearly as fast as max)
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save('image1.jpg')
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+)
+images[0].save("image1.jpg")
 
 
 # TEST 2 - no VRAM optimizations (maximum VRAM usage, fastest performance)
-context.vram_usage_level = 'high'
-load_model(context, 'stable-diffusion') # reload the model, to apply the change to VRAM optimization
+context.vram_usage_level = "high"
+load_model(
+    context, "stable-diffusion"
+)  # reload the model, to apply the change to VRAM optimization
 
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save('image2.jpg')
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+)
+images[0].save("image2.jpg")
 
 
 # TEST 3 - lowest VRAM usage, slowest performance (for GPUs with less than 4gb of VRAM)
-context.vram_usage_level = 'low'
-load_model(context, 'stable-diffusion') # reload the model, to apply the change to VRAM optimization
+context.vram_usage_level = "low"
+load_model(
+    context, "stable-diffusion"
+)  # reload the model, to apply the change to VRAM optimization
 
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save('image3.jpg')
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+)
+images[0].save("image3.jpg")

--- a/examples/300-device-low-vram.py
+++ b/examples/300-device-low-vram.py
@@ -1,48 +1,29 @@
 import sdkit
-from sdkit.generate import generate_images
 from sdkit.models import load_model
+from sdkit.generate import generate_images
 
 # this example will generate an image, using 3 different VRAM configurations.
 
 context = sdkit.Context()
-context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
-load_model(context, "stable-diffusion")
+context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
+load_model(context, 'stable-diffusion')
 
-# TEST 1 - default (balanced) VRAM optimizations (much lower VRAM usage,
-# performance is nearly as fast as max)
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-)
-images[0].save("image1.jpg")
+# TEST 1 - default (balanced) VRAM optimizations (much lower VRAM usage, performance is nearly as fast as max)
+images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images[0].save('image1.jpg')
 
 
 # TEST 2 - no VRAM optimizations (maximum VRAM usage, fastest performance)
-context.vram_usage_level = "high"
-load_model(context, "stable-diffusion")  # reload the model, to apply the change to VRAM optimization
+context.vram_usage_level = 'high'
+load_model(context, 'stable-diffusion') # reload the model, to apply the change to VRAM optimization
 
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-)
-images[0].save("image2.jpg")
+images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images[0].save('image2.jpg')
 
 
 # TEST 3 - lowest VRAM usage, slowest performance (for GPUs with less than 4gb of VRAM)
-context.vram_usage_level = "low"
-load_model(context, "stable-diffusion")  # reload the model, to apply the change to VRAM optimization
+context.vram_usage_level = 'low'
+load_model(context, 'stable-diffusion') # reload the model, to apply the change to VRAM optimization
 
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-)
-images[0].save("image3.jpg")
+images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images[0].save('image3.jpg')

--- a/examples/301-device-run_on_different_gpu.py
+++ b/examples/301-device-run_on_different_gpu.py
@@ -1,6 +1,6 @@
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
+from sdkit.models import load_model
 
 context = sdkit.Context()
 context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'

--- a/examples/301-device-run_on_different_gpu.py
+++ b/examples/301-device-run_on_different_gpu.py
@@ -3,11 +3,11 @@ from sdkit.generate import generate_images
 from sdkit.models import load_model
 
 context = sdkit.Context()
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
-context.device = 'cuda:1' # assuming the PC has a second GPU with the id 'cuda:1'
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
+context.device = "cuda:1"  # assuming the PC has a second GPU with the id 'cuda:1'
 
-load_model(context, 'stable-diffusion')
+load_model(context, "stable-diffusion")
 
 # generate image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save('image_from_second_gpu.jpg')
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
+images[0].save("image_from_second_gpu.jpg")

--- a/examples/301-device-run_on_different_gpu.py
+++ b/examples/301-device-run_on_different_gpu.py
@@ -3,11 +3,17 @@ from sdkit.models import load_model
 from sdkit.generate import generate_images
 
 context = sdkit.Context()
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
-context.device = 'cuda:1' # assuming the PC has a second GPU with the id 'cuda:1'
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
+context.device = "cuda:1"  # assuming the PC has a second GPU with the id 'cuda:1'
 
-load_model(context, 'stable-diffusion')
+load_model(context, "stable-diffusion")
 
 # generate image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save('image_from_second_gpu.jpg')
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+)
+images[0].save("image_from_second_gpu.jpg")

--- a/examples/301-device-run_on_different_gpu.py
+++ b/examples/301-device-run_on_different_gpu.py
@@ -1,19 +1,13 @@
 import sdkit
-from sdkit.generate import generate_images
 from sdkit.models import load_model
+from sdkit.generate import generate_images
 
 context = sdkit.Context()
-context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
-context.device = "cuda:1"  # assuming the PC has a second GPU with the id 'cuda:1'
+context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
+context.device = 'cuda:1' # assuming the PC has a second GPU with the id 'cuda:1'
 
-load_model(context, "stable-diffusion")
+load_model(context, 'stable-diffusion')
 
 # generate image
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-)
-images[0].save("image_from_second_gpu.jpg")
+images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images[0].save('image_from_second_gpu.jpg')

--- a/examples/301-device-run_on_different_gpu.py
+++ b/examples/301-device-run_on_different_gpu.py
@@ -1,6 +1,6 @@
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
+from sdkit.models import load_model
 
 context = sdkit.Context()
 context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"

--- a/examples/302-device-run_on_cpu.py
+++ b/examples/302-device-run_on_cpu.py
@@ -1,19 +1,13 @@
 import sdkit
-from sdkit.generate import generate_images
 from sdkit.models import load_model
+from sdkit.generate import generate_images
 
 context = sdkit.Context()
-context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
-context.device = "cpu"
+context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
+context.device = 'cpu'
 
-load_model(context, "stable-diffusion")
+load_model(context, 'stable-diffusion')
 
 # generate image
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-)
-images[0].save("image_from_cpu.jpg")
+images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images[0].save('image_from_cpu.jpg')

--- a/examples/302-device-run_on_cpu.py
+++ b/examples/302-device-run_on_cpu.py
@@ -1,6 +1,6 @@
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
+from sdkit.models import load_model
 
 context = sdkit.Context()
 context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'

--- a/examples/302-device-run_on_cpu.py
+++ b/examples/302-device-run_on_cpu.py
@@ -3,11 +3,17 @@ from sdkit.models import load_model
 from sdkit.generate import generate_images
 
 context = sdkit.Context()
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
-context.device = 'cpu'
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
+context.device = "cpu"
 
-load_model(context, 'stable-diffusion')
+load_model(context, "stable-diffusion")
 
 # generate image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save('image_from_cpu.jpg')
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+)
+images[0].save("image_from_cpu.jpg")

--- a/examples/302-device-run_on_cpu.py
+++ b/examples/302-device-run_on_cpu.py
@@ -1,6 +1,6 @@
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
+from sdkit.models import load_model
 
 context = sdkit.Context()
 context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"

--- a/examples/302-device-run_on_cpu.py
+++ b/examples/302-device-run_on_cpu.py
@@ -3,11 +3,11 @@ from sdkit.generate import generate_images
 from sdkit.models import load_model
 
 context = sdkit.Context()
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
-context.device = 'cpu'
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
+context.device = "cpu"
 
-load_model(context, 'stable-diffusion')
+load_model(context, "stable-diffusion")
 
 # generate image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save('image_from_cpu.jpg')
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
+images[0].save("image_from_cpu.jpg")

--- a/examples/304-device-run_on_multiple_gpus.py
+++ b/examples/304-device-run_on_multiple_gpus.py
@@ -5,31 +5,40 @@ from sdkit.utils import log
 
 import threading
 
+
 def render_thread(device):
-    log.info(f'starting on device {device}')
+    log.info(f"starting on device {device}")
     context = sdkit.Context()
-    context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
+    context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
     context.device = device
 
-    load_model(context, 'stable-diffusion')
+    load_model(context, "stable-diffusion")
 
     # generate image
-    log.info(f'generating on device {device}')
-    images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-    images[0].save(f'image_from_{device}.jpg')
+    log.info(f"generating on device {device}")
+    images = generate_images(
+        context,
+        prompt="Photograph of an astronaut riding a horse",
+        seed=42,
+        width=512,
+        height=512,
+    )
+    images[0].save(f"image_from_{device}.jpg")
 
-    log.info(f'finished generating on device {device}')
+    log.info(f"finished generating on device {device}")
+
 
 def start_thread(device):
-    thread = threading.Thread(target=render_thread, kwargs={'device': device})
+    thread = threading.Thread(target=render_thread, kwargs={"device": device})
     thread.daemon = True
-    thread.name = f'SD-{device}'
+    thread.name = f"SD-{device}"
     thread.start()
     return thread
 
+
 # assuming the PC has two CUDA-compatible GPUs, start on the first two GPUs: cuda:0 and cuda:1
-t0 = start_thread('cuda:0')
-t1 = start_thread('cuda:1')
+t0 = start_thread("cuda:0")
+t1 = start_thread("cuda:1")
 
 t0.join()
 t1.join()

--- a/examples/304-device-run_on_multiple_gpus.py
+++ b/examples/304-device-run_on_multiple_gpus.py
@@ -1,9 +1,10 @@
+import threading
+
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
+from sdkit.models import load_model
 from sdkit.utils import log
 
-import threading
 
 def render_thread(device):
     log.info(f'starting on device {device}')

--- a/examples/304-device-run_on_multiple_gpus.py
+++ b/examples/304-device-run_on_multiple_gpus.py
@@ -1,45 +1,35 @@
-import threading
-
 import sdkit
-from sdkit.generate import generate_images
 from sdkit.models import load_model
+from sdkit.generate import generate_images
 from sdkit.utils import log
 
+import threading
 
 def render_thread(device):
-    log.info(f"starting on device {device}")
+    log.info(f'starting on device {device}')
     context = sdkit.Context()
-    context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
+    context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
     context.device = device
 
-    load_model(context, "stable-diffusion")
+    load_model(context, 'stable-diffusion')
 
     # generate image
-    log.info(f"generating on device {device}")
-    images = generate_images(
-        context,
-        prompt="Photograph of an astronaut riding a horse",
-        seed=42,
-        width=512,
-        height=512,
-    )
-    images[0].save(f"image_from_{device}.jpg")
+    log.info(f'generating on device {device}')
+    images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+    images[0].save(f'image_from_{device}.jpg')
 
-    log.info(f"finished generating on device {device}")
-
+    log.info(f'finished generating on device {device}')
 
 def start_thread(device):
-    thread = threading.Thread(target=render_thread, kwargs={"device": device})
+    thread = threading.Thread(target=render_thread, kwargs={'device': device})
     thread.daemon = True
-    thread.name = f"SD-{device}"
+    thread.name = f'SD-{device}'
     thread.start()
     return thread
 
-
-# assuming the PC has two CUDA-compatible GPUs, start on the first two GPUs:
-# cuda:0 and cuda:1
-t0 = start_thread("cuda:0")
-t1 = start_thread("cuda:1")
+# assuming the PC has two CUDA-compatible GPUs, start on the first two GPUs: cuda:0 and cuda:1
+t0 = start_thread('cuda:0')
+t1 = start_thread('cuda:1')
 
 t0.join()
 t1.join()

--- a/examples/304-device-run_on_multiple_gpus.py
+++ b/examples/304-device-run_on_multiple_gpus.py
@@ -36,7 +36,8 @@ def start_thread(device):
     return thread
 
 
-# assuming the PC has two CUDA-compatible GPUs, start on the first two GPUs: cuda:0 and cuda:1
+# assuming the PC has two CUDA-compatible GPUs, start on the first two GPUs:
+# cuda:0 and cuda:1
 t0 = start_thread("cuda:0")
 t1 = start_thread("cuda:1")
 

--- a/examples/304-device-run_on_multiple_gpus.py
+++ b/examples/304-device-run_on_multiple_gpus.py
@@ -1,9 +1,9 @@
-import sdkit
-from sdkit.models import load_model
-from sdkit.generate import generate_images
-from sdkit.utils import log
-
 import threading
+
+import sdkit
+from sdkit.generate import generate_images
+from sdkit.models import load_model
+from sdkit.utils import log
 
 
 def render_thread(device):

--- a/examples/304-device-run_on_multiple_gpus.py
+++ b/examples/304-device-run_on_multiple_gpus.py
@@ -7,30 +7,34 @@ from sdkit.utils import log
 
 
 def render_thread(device):
-    log.info(f'starting on device {device}')
+    log.info(f"starting on device {device}")
     context = sdkit.Context()
-    context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
+    context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
     context.device = device
 
-    load_model(context, 'stable-diffusion')
+    load_model(context, "stable-diffusion")
 
     # generate image
-    log.info(f'generating on device {device}')
-    images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-    images[0].save(f'image_from_{device}.jpg')
+    log.info(f"generating on device {device}")
+    images = generate_images(
+        context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512
+    )
+    images[0].save(f"image_from_{device}.jpg")
 
-    log.info(f'finished generating on device {device}')
+    log.info(f"finished generating on device {device}")
+
 
 def start_thread(device):
-    thread = threading.Thread(target=render_thread, kwargs={'device': device})
+    thread = threading.Thread(target=render_thread, kwargs={"device": device})
     thread.daemon = True
-    thread.name = f'SD-{device}'
+    thread.name = f"SD-{device}"
     thread.start()
     return thread
 
+
 # assuming the PC has two CUDA-compatible GPUs, start on the first two GPUs: cuda:0 and cuda:1
-t0 = start_thread('cuda:0')
-t1 = start_thread('cuda:1')
+t0 = start_thread("cuda:0")
+t1 = start_thread("cuda:1")
 
 t0.join()
 t1.join()

--- a/examples/305-device-full_precision.py
+++ b/examples/305-device-full_precision.py
@@ -1,6 +1,6 @@
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
+from sdkit.models import load_model
 
 context = sdkit.Context()
 context.half_precision = False  # loads in full precision (i.e. float32, instead of float16). consumes more VRAM

--- a/examples/305-device-full_precision.py
+++ b/examples/305-device-full_precision.py
@@ -3,7 +3,8 @@ from sdkit.generate import generate_images
 from sdkit.models import load_model
 
 context = sdkit.Context()
-context.half_precision = False  # loads in full precision (i.e. float32, instead of float16). consumes more VRAM
+# loads in full precision (i.e. float32, instead of float16). consumes more VRAM
+context.half_precision = False
 context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
 
 load_model(context, "stable-diffusion")
@@ -16,4 +17,4 @@ images = generate_images(
     width=512,
     height=512,
 )
-images[0].save(f"image.jpg")
+images[0].save("image.jpg")

--- a/examples/305-device-full_precision.py
+++ b/examples/305-device-full_precision.py
@@ -1,6 +1,6 @@
 import sdkit
-from sdkit.models import load_model
 from sdkit.generate import generate_images
+from sdkit.models import load_model
 
 context = sdkit.Context()
 context.half_precision = False # loads in full precision (i.e. float32, instead of float16). consumes more VRAM

--- a/examples/305-device-full_precision.py
+++ b/examples/305-device-full_precision.py
@@ -1,20 +1,13 @@
 import sdkit
-from sdkit.generate import generate_images
 from sdkit.models import load_model
+from sdkit.generate import generate_images
 
 context = sdkit.Context()
-# loads in full precision (i.e. float32, instead of float16). consumes more VRAM
-context.half_precision = False
-context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
+context.half_precision = False # loads in full precision (i.e. float32, instead of float16). consumes more VRAM
+context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
 
-load_model(context, "stable-diffusion")
+load_model(context, 'stable-diffusion')
 
 # generate image
-images = generate_images(
-    context,
-    prompt="Photograph of an astronaut riding a horse",
-    seed=42,
-    width=512,
-    height=512,
-)
-images[0].save("image.jpg")
+images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
+images[0].save(f'image.jpg')

--- a/examples/305-device-full_precision.py
+++ b/examples/305-device-full_precision.py
@@ -3,11 +3,17 @@ from sdkit.models import load_model
 from sdkit.generate import generate_images
 
 context = sdkit.Context()
-context.half_precision = False # loads in full precision (i.e. float32, instead of float16). consumes more VRAM
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
+context.half_precision = False  # loads in full precision (i.e. float32, instead of float16). consumes more VRAM
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
 
-load_model(context, 'stable-diffusion')
+load_model(context, "stable-diffusion")
 
 # generate image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save(f'image.jpg')
+images = generate_images(
+    context,
+    prompt="Photograph of an astronaut riding a horse",
+    seed=42,
+    width=512,
+    height=512,
+)
+images[0].save(f"image.jpg")

--- a/examples/305-device-full_precision.py
+++ b/examples/305-device-full_precision.py
@@ -3,11 +3,11 @@ from sdkit.generate import generate_images
 from sdkit.models import load_model
 
 context = sdkit.Context()
-context.half_precision = False # loads in full precision (i.e. float32, instead of float16). consumes more VRAM
-context.model_paths['stable-diffusion'] = 'D:\\path\\to\\sd-v1-4.ckpt'
+context.half_precision = False  # loads in full precision (i.e. float32, instead of float16). consumes more VRAM
+context.model_paths["stable-diffusion"] = "D:\\path\\to\\sd-v1-4.ckpt"
 
-load_model(context, 'stable-diffusion')
+load_model(context, "stable-diffusion")
 
 # generate image
-images = generate_images(context, prompt='Photograph of an astronaut riding a horse', seed=42, width=512, height=512)
-images[0].save(f'image.jpg')
+images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
+images[0].save(f"image.jpg")

--- a/examples/305-device-full_precision.py
+++ b/examples/305-device-full_precision.py
@@ -10,4 +10,4 @@ load_model(context, "stable-diffusion")
 
 # generate image
 images = generate_images(context, prompt="Photograph of an astronaut riding a horse", seed=42, width=512, height=512)
-images[0].save(f"image.jpg")
+images[0].save("image.jpg")

--- a/examples/400-security-scan_model.py
+++ b/examples/400-security-scan_model.py
@@ -6,10 +6,16 @@ from sdkit.utils import log
 # lots of models, and then disable model-scanning each time a model is loaded
 # to improve load time.
 
-model_path = 'D:\\path\\to\\malicious_model.ckpt'
+model_path = "D:\\path\\to\\malicious_model.ckpt"
 scan_result = scan_model(model_path)
 
 if scan_result.issues_count > 0 or scan_result.infected_files > 0:
-    log.warn(f":warning: [bold red]Scan %s: %d scanned, %d issue, %d infected.[/bold red]" % (model_path, scan_result.scanned_files, scan_result.issues_count, scan_result.infected_files))
+    log.warn(
+        f":warning: [bold red]Scan %s: %d scanned, %d issue, %d infected.[/bold red]"
+        % (model_path, scan_result.scanned_files, scan_result.issues_count, scan_result.infected_files)
+    )
 else:
-    log.debug("Scan %s: [green]%d scanned, %d issue, %d infected.[/green]" % (model_path, scan_result.scanned_files, scan_result.issues_count, scan_result.infected_files))
+    log.debug(
+        "Scan %s: [green]%d scanned, %d issue, %d infected.[/green]"
+        % (model_path, scan_result.scanned_files, scan_result.issues_count, scan_result.infected_files)
+    )

--- a/examples/400-security-scan_model.py
+++ b/examples/400-security-scan_model.py
@@ -11,7 +11,7 @@ scan_result = scan_model(model_path)
 
 if scan_result.issues_count > 0 or scan_result.infected_files > 0:
     log.warn(
-        f":warning: [bold red]Scan %s: %d scanned, %d issue, %d infected.[/bold red]"
+        ":warning: [bold red]Scan %s: %d scanned, %d issue, %d infected.[/bold red]"
         % (model_path, scan_result.scanned_files, scan_result.issues_count, scan_result.infected_files)
     )
 else:

--- a/examples/400-security-scan_model.py
+++ b/examples/400-security-scan_model.py
@@ -6,26 +6,10 @@ from sdkit.utils import log
 # lots of models, and then disable model-scanning each time a model is loaded
 # to improve load time.
 
-model_path = "D:\\path\\to\\malicious_model.ckpt"
+model_path = 'D:\\path\\to\\malicious_model.ckpt'
 scan_result = scan_model(model_path)
 
 if scan_result.issues_count > 0 or scan_result.infected_files > 0:
-    log.warn(
-        ":warning: [bold red]Scan %s: %d scanned, %d issue, %d infected.[/bold red]"
-        % (
-            model_path,
-            scan_result.scanned_files,
-            scan_result.issues_count,
-            scan_result.infected_files,
-        )
-    )
+    log.warn(f":warning: [bold red]Scan %s: %d scanned, %d issue, %d infected.[/bold red]" % (model_path, scan_result.scanned_files, scan_result.issues_count, scan_result.infected_files))
 else:
-    log.debug(
-        "Scan %s: [green]%d scanned, %d issue, %d infected.[/green]"
-        % (
-            model_path,
-            scan_result.scanned_files,
-            scan_result.issues_count,
-            scan_result.infected_files,
-        )
-    )
+    log.debug("Scan %s: [green]%d scanned, %d issue, %d infected.[/green]" % (model_path, scan_result.scanned_files, scan_result.issues_count, scan_result.infected_files))

--- a/examples/400-security-scan_model.py
+++ b/examples/400-security-scan_model.py
@@ -11,7 +11,7 @@ scan_result = scan_model(model_path)
 
 if scan_result.issues_count > 0 or scan_result.infected_files > 0:
     log.warn(
-        f":warning: [bold red]Scan %s: %d scanned, %d issue, %d infected.[/bold red]"
+        ":warning: [bold red]Scan %s: %d scanned, %d issue, %d infected.[/bold red]"
         % (
             model_path,
             scan_result.scanned_files,

--- a/examples/400-security-scan_model.py
+++ b/examples/400-security-scan_model.py
@@ -6,10 +6,26 @@ from sdkit.utils import log
 # lots of models, and then disable model-scanning each time a model is loaded
 # to improve load time.
 
-model_path = 'D:\\path\\to\\malicious_model.ckpt'
+model_path = "D:\\path\\to\\malicious_model.ckpt"
 scan_result = scan_model(model_path)
 
 if scan_result.issues_count > 0 or scan_result.infected_files > 0:
-    log.warn(f":warning: [bold red]Scan %s: %d scanned, %d issue, %d infected.[/bold red]" % (model_path, scan_result.scanned_files, scan_result.issues_count, scan_result.infected_files))
+    log.warn(
+        f":warning: [bold red]Scan %s: %d scanned, %d issue, %d infected.[/bold red]"
+        % (
+            model_path,
+            scan_result.scanned_files,
+            scan_result.issues_count,
+            scan_result.infected_files,
+        )
+    )
 else:
-    log.debug("Scan %s: [green]%d scanned, %d issue, %d infected.[/green]" % (model_path, scan_result.scanned_files, scan_result.issues_count, scan_result.infected_files))
+    log.debug(
+        "Scan %s: [green]%d scanned, %d issue, %d infected.[/green]"
+        % (
+            model_path,
+            scan_result.scanned_files,
+            scan_result.issues_count,
+            scan_result.infected_files,
+        )
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = ["stable diffusion", "ai", "art"]
 profile = "black"
 
 [tool.black]
-line-length = 88
+line-length = 120
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,6 @@ keywords = ["stable diffusion", "ai", "art"]
 [project.urls]
 "Homepage" = "https://github.com/easydiffusion/sdkit"
 "Bug Tracker" = "https://github.com/easydiffusion/sdkit/issues"
+
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,20 @@ keywords = ["stable diffusion", "ai", "art"]
 
 [tool.isort]
 profile = "black"
+
+[tool.black]
+line-length = 88
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+black==23.1.0
+isort==5.12.0
+flake8==6.0.0
+autoflake==2.0.1

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -1,8 +1,8 @@
 import sys
-import pandas
 
 # import seaborn as sns
 import matplotlib.pyplot as plt
+import pandas
 
 stable = pandas.read_csv(sys.argv[1])
 beta = pandas.read_csv(sys.argv[2])

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -23,12 +23,8 @@ del (
     beta["overall_status"],
 )
 
-bad = (
-    stable["max_vram (GB)"] < beta["max_vram (GB)"]
-)  # & (stable['model_filename'] == 'sd-v1-4.ckpt')
-good = (
-    stable["max_vram (GB)"] > beta["max_vram (GB)"]
-)  # & (stable['model_filename'] == 'sd-v1-4.ckpt')
+bad = stable["max_vram (GB)"] < beta["max_vram (GB)"]  # & (stable['model_filename'] == 'sd-v1-4.ckpt')
+good = stable["max_vram (GB)"] > beta["max_vram (GB)"]  # & (stable['model_filename'] == 'sd-v1-4.ckpt')
 
 print("bad results", bad)
 print("good results", good)

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -1,28 +1,29 @@
 import sys
+import pandas
+# import seaborn as sns
+import matplotlib.pyplot as plt
 
-import pandas as pd
+stable = pandas.read_csv(sys.argv[1])
+beta = pandas.read_csv(sys.argv[2])
 
-stable = pd.read_csv(sys.argv[1])
-beta = pd.read_csv(sys.argv[2])
+del stable['vram_usage'], stable['ram_usage']
+del beta['vram_usage'], beta['ram_usage']
 
-del stable["vram_usage"], stable["ram_usage"]
-del beta["vram_usage"], beta["ram_usage"]
+del stable['render_test'], stable['vram_tp90'], stable['vram_spike_test'], stable['overall_status']
+del beta['render_test'], beta['vram_tp90'], beta['vram_spike_test'], beta['overall_status']
 
-del (
-    stable["render_test"],
-    stable["vram_tp90"],
-    stable["vram_spike_test"],
-    stable["overall_status"],
-)
-del (
-    beta["render_test"],
-    beta["vram_tp90"],
-    beta["vram_spike_test"],
-    beta["overall_status"],
-)
+bad = (stable['max_vram (GB)'] < beta['max_vram (GB)']) # & (stable['model_filename'] == 'sd-v1-4.ckpt')
+good = (stable['max_vram (GB)'] > beta['max_vram (GB)']) # & (stable['model_filename'] == 'sd-v1-4.ckpt')
 
-bad = stable["max_vram (GB)"] < beta["max_vram (GB)"]  # & (stable['model_filename'] == 'sd-v1-4.ckpt')
-good = stable["max_vram (GB)"] > beta["max_vram (GB)"]  # & (stable['model_filename'] == 'sd-v1-4.ckpt')
+print('bad results', bad)
+print('good results', good)
 
-print("bad results", bad)
-print("good results", good)
+# combined = pandas.concat([stable, beta], axis=0, ignore_index=False)
+# combined['version'] = (len(stable)*('v2.4',) + len(beta)*('v2.5',))
+# combined.reset_index(inplace=True)
+
+# combined['index'] = combined['model_filename'].apply(lambda x: x.replace('.ckpt', '').replace('.safetensors', '')) + ',' + combined['vram_usage_level'] + ',' + combined['image_size']
+
+# sns.catplot(x='index', y='max_vram (GB)', hue='version', kind='bar', data=combined)
+# plt.xticks(rotation=90, fontsize=6)
+# plt.show()

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -1,7 +1,6 @@
 import sys
 
 # import seaborn as sns
-import matplotlib.pyplot as plt
 import pandas
 
 stable = pandas.read_csv(sys.argv[1])

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -1,11 +1,9 @@
 import sys
 
-# import seaborn as sns
-import matplotlib.pyplot as plt
-import pandas
+import pandas as pd
 
-stable = pandas.read_csv(sys.argv[1])
-beta = pandas.read_csv(sys.argv[2])
+stable = pd.read_csv(sys.argv[1])
+beta = pd.read_csv(sys.argv[2])
 
 del stable["vram_usage"], stable["ram_usage"]
 del beta["vram_usage"], beta["ram_usage"]
@@ -28,13 +26,3 @@ good = stable["max_vram (GB)"] > beta["max_vram (GB)"]  # & (stable['model_filen
 
 print("bad results", bad)
 print("good results", good)
-
-# combined = pandas.concat([stable, beta], axis=0, ignore_index=False)
-# combined['version'] = (len(stable)*('v2.4',) + len(beta)*('v2.5',))
-# combined.reset_index(inplace=True)
-
-# combined['index'] = combined['model_filename'].apply(lambda x: x.replace('.ckpt', '').replace('.safetensors', '')) + ',' + combined['vram_usage_level'] + ',' + combined['image_size']
-
-# sns.catplot(x='index', y='max_vram (GB)', hue='version', kind='bar', data=combined)
-# plt.xticks(rotation=90, fontsize=6)
-# plt.show()

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -1,22 +1,37 @@
 import sys
 import pandas
+
 # import seaborn as sns
 import matplotlib.pyplot as plt
 
 stable = pandas.read_csv(sys.argv[1])
 beta = pandas.read_csv(sys.argv[2])
 
-del stable['vram_usage'], stable['ram_usage']
-del beta['vram_usage'], beta['ram_usage']
+del stable["vram_usage"], stable["ram_usage"]
+del beta["vram_usage"], beta["ram_usage"]
 
-del stable['render_test'], stable['vram_tp90'], stable['vram_spike_test'], stable['overall_status']
-del beta['render_test'], beta['vram_tp90'], beta['vram_spike_test'], beta['overall_status']
+del (
+    stable["render_test"],
+    stable["vram_tp90"],
+    stable["vram_spike_test"],
+    stable["overall_status"],
+)
+del (
+    beta["render_test"],
+    beta["vram_tp90"],
+    beta["vram_spike_test"],
+    beta["overall_status"],
+)
 
-bad = (stable['max_vram (GB)'] < beta['max_vram (GB)']) # & (stable['model_filename'] == 'sd-v1-4.ckpt')
-good = (stable['max_vram (GB)'] > beta['max_vram (GB)']) # & (stable['model_filename'] == 'sd-v1-4.ckpt')
+bad = (
+    stable["max_vram (GB)"] < beta["max_vram (GB)"]
+)  # & (stable['model_filename'] == 'sd-v1-4.ckpt')
+good = (
+    stable["max_vram (GB)"] > beta["max_vram (GB)"]
+)  # & (stable['model_filename'] == 'sd-v1-4.ckpt')
 
-print('bad results', bad)
-print('good results', good)
+print("bad results", bad)
+print("good results", good)
 
 # combined = pandas.concat([stable, beta], axis=0, ignore_index=False)
 # combined['version'] = (len(stable)*('v2.4',) + len(beta)*('v2.5',))

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -1,22 +1,23 @@
 import sys
 import pandas
+
 # import seaborn as sns
 import matplotlib.pyplot as plt
 
 stable = pandas.read_csv(sys.argv[1])
 beta = pandas.read_csv(sys.argv[2])
 
-del stable['vram_usage'], stable['ram_usage']
-del beta['vram_usage'], beta['ram_usage']
+del stable["vram_usage"], stable["ram_usage"]
+del beta["vram_usage"], beta["ram_usage"]
 
-del stable['render_test'], stable['vram_tp90'], stable['vram_spike_test'], stable['overall_status']
-del beta['render_test'], beta['vram_tp90'], beta['vram_spike_test'], beta['overall_status']
+del stable["render_test"], stable["vram_tp90"], stable["vram_spike_test"], stable["overall_status"]
+del beta["render_test"], beta["vram_tp90"], beta["vram_spike_test"], beta["overall_status"]
 
-bad = (stable['max_vram (GB)'] < beta['max_vram (GB)']) # & (stable['model_filename'] == 'sd-v1-4.ckpt')
-good = (stable['max_vram (GB)'] > beta['max_vram (GB)']) # & (stable['model_filename'] == 'sd-v1-4.ckpt')
+bad = stable["max_vram (GB)"] < beta["max_vram (GB)"]  # & (stable['model_filename'] == 'sd-v1-4.ckpt')
+good = stable["max_vram (GB)"] > beta["max_vram (GB)"]  # & (stable['model_filename'] == 'sd-v1-4.ckpt')
 
-print('bad results', bad)
-print('good results', good)
+print("bad results", bad)
+print("good results", good)
 
 # combined = pandas.concat([stable, beta], axis=0, ignore_index=False)
 # combined['version'] = (len(stable)*('v2.4',) + len(beta)*('v2.5',))

--- a/scripts/download_all_models.py
+++ b/scripts/download_all_models.py
@@ -1,30 +1,21 @@
-import argparse
 import os
 import sys
-
+import argparse
 import requests
 
 # args
 parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--models-dir",
-    required=True,
-    help="Folder path where the models will be downloaded, with a subdir for each model type",
-)
-parser.add_argument(
-    "--hash-only",
-    action="store_true",
-    default=False,
-    help="Don't download, just calculate the hashes of the models in the downloaded dir",
-)
+parser.add_argument('--models-dir', required=True, help="Folder path where the models will be downloaded, with a subdir for each model type")
+parser.add_argument('--hash-only', action='store_true', default=False, help="Don't download, just calculate the hashes of the models in the downloaded dir")
 args = parser.parse_args()
 
 if len(sys.argv) < 2:
-    print("Error: need to provide a folder path as the first argument")
+    print('Error: need to provide a folder path as the first argument')
     exit(1)
 
 # setup
-from sdkit.models import download_model, get_models_db, resolve_downloaded_model_path
+from sdkit.models import download_model, resolve_downloaded_model_path
+from sdkit.models import get_models_db
 from sdkit.utils import hash_file_quick
 
 db = get_models_db()
@@ -40,20 +31,16 @@ if os.path.exists(download_dir):
             if not args.hash_only:
                 download_model(model_type, model_id, download_base_dir=download_dir)
 
-            model_path = resolve_downloaded_model_path(
-                model_type=model_type, model_id=model_id, download_base_dir=download_dir
-            )
+            model_path = resolve_downloaded_model_path(model_type=model_type, model_id=model_id, download_base_dir=download_dir)
             quick_hash = hash_file_quick(model_path)
             model_info = db[model_type][model_id]
-            expected_quick_hash = model_info["quick_hash"]
-            expected_size = int(requests.get(model_info["url"], stream=True).headers["content-length"])
+            expected_quick_hash = model_info['quick_hash']
+            expected_size = int(requests.get(model_info['url'], stream=True).headers['content-length'])
             actual_size = os.path.getsize(model_path)
 
             if quick_hash != expected_quick_hash:
-                print(
-                    f"""ERROR! {model_type} {model_id}:
+                print(f'''ERROR! {model_type} {model_id}:
   expected hash:\t{expected_quick_hash}
   actual:\t\t{quick_hash}
   expected size:\t{expected_size}
-  actual size:\t\t{actual_size}"""
-                )
+  actual size:\t\t{actual_size}''')

--- a/scripts/download_all_models.py
+++ b/scripts/download_all_models.py
@@ -1,6 +1,7 @@
+import argparse
 import os
 import sys
-import argparse
+
 import requests
 
 # args
@@ -23,8 +24,7 @@ if len(sys.argv) < 2:
     exit(1)
 
 # setup
-from sdkit.models import download_model, resolve_downloaded_model_path
-from sdkit.models import get_models_db
+from sdkit.models import download_model, get_models_db, resolve_downloaded_model_path
 from sdkit.utils import hash_file_quick
 
 db = get_models_db()

--- a/scripts/download_all_models.py
+++ b/scripts/download_all_models.py
@@ -5,12 +5,21 @@ import requests
 
 # args
 parser = argparse.ArgumentParser()
-parser.add_argument('--models-dir', required=True, help="Folder path where the models will be downloaded, with a subdir for each model type")
-parser.add_argument('--hash-only', action='store_true', default=False, help="Don't download, just calculate the hashes of the models in the downloaded dir")
+parser.add_argument(
+    "--models-dir",
+    required=True,
+    help="Folder path where the models will be downloaded, with a subdir for each model type",
+)
+parser.add_argument(
+    "--hash-only",
+    action="store_true",
+    default=False,
+    help="Don't download, just calculate the hashes of the models in the downloaded dir",
+)
 args = parser.parse_args()
 
 if len(sys.argv) < 2:
-    print('Error: need to provide a folder path as the first argument')
+    print("Error: need to provide a folder path as the first argument")
     exit(1)
 
 # setup
@@ -20,7 +29,9 @@ from sdkit.utils import hash_file_quick
 
 db = get_models_db()
 
-models_to_download = {model_type: list(models.keys()) for model_type, models in db.items()}
+models_to_download = {
+    model_type: list(models.keys()) for model_type, models in db.items()
+}
 download_dir = args.models_dir
 
 os.makedirs(download_dir, exist_ok=True)
@@ -31,16 +42,22 @@ if os.path.exists(download_dir):
             if not args.hash_only:
                 download_model(model_type, model_id, download_base_dir=download_dir)
 
-            model_path = resolve_downloaded_model_path(model_type=model_type, model_id=model_id, download_base_dir=download_dir)
+            model_path = resolve_downloaded_model_path(
+                model_type=model_type, model_id=model_id, download_base_dir=download_dir
+            )
             quick_hash = hash_file_quick(model_path)
             model_info = db[model_type][model_id]
-            expected_quick_hash = model_info['quick_hash']
-            expected_size = int(requests.get(model_info['url'], stream=True).headers['content-length'])
+            expected_quick_hash = model_info["quick_hash"]
+            expected_size = int(
+                requests.get(model_info["url"], stream=True).headers["content-length"]
+            )
             actual_size = os.path.getsize(model_path)
 
             if quick_hash != expected_quick_hash:
-                print(f'''ERROR! {model_type} {model_id}:
+                print(
+                    f"""ERROR! {model_type} {model_id}:
   expected hash:\t{expected_quick_hash}
   actual:\t\t{quick_hash}
   expected size:\t{expected_size}
-  actual size:\t\t{actual_size}''')
+  actual size:\t\t{actual_size}"""
+                )

--- a/scripts/download_all_models.py
+++ b/scripts/download_all_models.py
@@ -29,9 +29,7 @@ from sdkit.utils import hash_file_quick
 
 db = get_models_db()
 
-models_to_download = {
-    model_type: list(models.keys()) for model_type, models in db.items()
-}
+models_to_download = {model_type: list(models.keys()) for model_type, models in db.items()}
 download_dir = args.models_dir
 
 os.makedirs(download_dir, exist_ok=True)
@@ -48,9 +46,7 @@ if os.path.exists(download_dir):
             quick_hash = hash_file_quick(model_path)
             model_info = db[model_type][model_id]
             expected_quick_hash = model_info["quick_hash"]
-            expected_size = int(
-                requests.get(model_info["url"], stream=True).headers["content-length"]
-            )
+            expected_size = int(requests.get(model_info["url"], stream=True).headers["content-length"])
             actual_size = os.path.getsize(model_path)
 
             if quick_hash != expected_quick_hash:

--- a/scripts/download_all_models.py
+++ b/scripts/download_all_models.py
@@ -5,12 +5,21 @@ import requests
 
 # args
 parser = argparse.ArgumentParser()
-parser.add_argument('--models-dir', required=True, help="Folder path where the models will be downloaded, with a subdir for each model type")
-parser.add_argument('--hash-only', action='store_true', default=False, help="Don't download, just calculate the hashes of the models in the downloaded dir")
+parser.add_argument(
+    "--models-dir",
+    required=True,
+    help="Folder path where the models will be downloaded, with a subdir for each model type",
+)
+parser.add_argument(
+    "--hash-only",
+    action="store_true",
+    default=False,
+    help="Don't download, just calculate the hashes of the models in the downloaded dir",
+)
 args = parser.parse_args()
 
 if len(sys.argv) < 2:
-    print('Error: need to provide a folder path as the first argument')
+    print("Error: need to provide a folder path as the first argument")
     exit(1)
 
 # setup
@@ -31,16 +40,20 @@ if os.path.exists(download_dir):
             if not args.hash_only:
                 download_model(model_type, model_id, download_base_dir=download_dir)
 
-            model_path = resolve_downloaded_model_path(model_type=model_type, model_id=model_id, download_base_dir=download_dir)
+            model_path = resolve_downloaded_model_path(
+                model_type=model_type, model_id=model_id, download_base_dir=download_dir
+            )
             quick_hash = hash_file_quick(model_path)
             model_info = db[model_type][model_id]
-            expected_quick_hash = model_info['quick_hash']
-            expected_size = int(requests.get(model_info['url'], stream=True).headers['content-length'])
+            expected_quick_hash = model_info["quick_hash"]
+            expected_size = int(requests.get(model_info["url"], stream=True).headers["content-length"])
             actual_size = os.path.getsize(model_path)
 
             if quick_hash != expected_quick_hash:
-                print(f'''ERROR! {model_type} {model_id}:
+                print(
+                    f"""ERROR! {model_type} {model_id}:
   expected hash:\t{expected_quick_hash}
   actual:\t\t{quick_hash}
   expected size:\t{expected_size}
-  actual size:\t\t{actual_size}''')
+  actual size:\t\t{actual_size}"""
+                )

--- a/scripts/print_quick_hashes.py
+++ b/scripts/print_quick_hashes.py
@@ -1,14 +1,18 @@
-'''
+"""
 Utility script for calculating quick hashes for all the entries in the models db.
 
 Usage:
 python print_quick_hashes.py --help
-'''
+"""
 import argparse
 
 # args
 parser = argparse.ArgumentParser(description="arg parser")
-parser.add_argument("--diff-only", action="store_true", help="Only show entries if the calculated quick-hash doesn't match the stored quick-hash")
+parser.add_argument(
+    "--diff-only",
+    action="store_true",
+    help="Only show entries if the calculated quick-hash doesn't match the stored quick-hash",
+)
 parser.set_defaults(diff_only=False)
 args = parser.parse_args()
 
@@ -20,17 +24,17 @@ models_db = get_models_db()
 hashes_found = {}
 
 if args.diff_only:
-    print('Printing quick-hashes for only those URLs that do not match the configured quick-hash')
+    print("Printing quick-hashes for only those URLs that do not match the configured quick-hash")
 
 for model_type, models in models_db.items():
-    print(f'{model_type} models:')
+    print(f"{model_type} models:")
 
     for model_id, model_info in models.items():
-        url = model_info['url']
+        url = model_info["url"]
         quick_hash = hash_url_quick(url)
-        if not args.diff_only or quick_hash != model_info.get('quick_hash'):
-            print(f'{model_id} = {quick_hash}')
+        if not args.diff_only or quick_hash != model_info.get("quick_hash"):
+            print(f"{model_id} = {quick_hash}")
         if quick_hash in hashes_found:
-            print(f'HASH CONFLICT! {quick_hash} already maps to {hashes_found[quick_hash]}')
+            print(f"HASH CONFLICT! {quick_hash} already maps to {hashes_found[quick_hash]}")
         else:
             hashes_found[quick_hash] = url

--- a/scripts/print_quick_hashes.py
+++ b/scripts/print_quick_hashes.py
@@ -1,14 +1,18 @@
-'''
+"""
 Utility script for calculating quick hashes for all the entries in the models db.
 
 Usage:
 python print_quick_hashes.py --help
-'''
+"""
 import argparse
 
 # args
 parser = argparse.ArgumentParser(description="arg parser")
-parser.add_argument("--diff-only", action="store_true", help="Only show entries if the calculated quick-hash doesn't match the stored quick-hash")
+parser.add_argument(
+    "--diff-only",
+    action="store_true",
+    help="Only show entries if the calculated quick-hash doesn't match the stored quick-hash",
+)
 parser.set_defaults(diff_only=False)
 args = parser.parse_args()
 
@@ -20,17 +24,21 @@ models_db = get_models_db()
 hashes_found = {}
 
 if args.diff_only:
-    print('Printing quick-hashes for only those URLs that do not match the configured quick-hash')
+    print(
+        "Printing quick-hashes for only those URLs that do not match the configured quick-hash"
+    )
 
 for model_type, models in models_db.items():
-    print(f'{model_type} models:')
+    print(f"{model_type} models:")
 
     for model_id, model_info in models.items():
-        url = model_info['url']
+        url = model_info["url"]
         quick_hash = hash_url_quick(url)
-        if not args.diff_only or quick_hash != model_info.get('quick_hash'):
-            print(f'{model_id} = {quick_hash}')
+        if not args.diff_only or quick_hash != model_info.get("quick_hash"):
+            print(f"{model_id} = {quick_hash}")
         if quick_hash in hashes_found:
-            print(f'HASH CONFLICT! {quick_hash} already maps to {hashes_found[quick_hash]}')
+            print(
+                f"HASH CONFLICT! {quick_hash} already maps to {hashes_found[quick_hash]}"
+            )
         else:
             hashes_found[quick_hash] = url

--- a/scripts/print_quick_hashes.py
+++ b/scripts/print_quick_hashes.py
@@ -1,18 +1,14 @@
-"""
+'''
 Utility script for calculating quick hashes for all the entries in the models db.
 
 Usage:
 python print_quick_hashes.py --help
-"""
+'''
 import argparse
 
 # args
 parser = argparse.ArgumentParser(description="arg parser")
-parser.add_argument(
-    "--diff-only",
-    action="store_true",
-    help="Only show entries if the calculated quick-hash doesn't match the stored quick-hash",
-)
+parser.add_argument("--diff-only", action="store_true", help="Only show entries if the calculated quick-hash doesn't match the stored quick-hash")
 parser.set_defaults(diff_only=False)
 args = parser.parse_args()
 
@@ -24,17 +20,17 @@ models_db = get_models_db()
 hashes_found = {}
 
 if args.diff_only:
-    print("Printing quick-hashes for only those URLs that do not match the configured quick-hash")
+    print('Printing quick-hashes for only those URLs that do not match the configured quick-hash')
 
 for model_type, models in models_db.items():
-    print(f"{model_type} models:")
+    print(f'{model_type} models:')
 
     for model_id, model_info in models.items():
-        url = model_info["url"]
+        url = model_info['url']
         quick_hash = hash_url_quick(url)
-        if not args.diff_only or quick_hash != model_info.get("quick_hash"):
-            print(f"{model_id} = {quick_hash}")
+        if not args.diff_only or quick_hash != model_info.get('quick_hash'):
+            print(f'{model_id} = {quick_hash}')
         if quick_hash in hashes_found:
-            print(f"HASH CONFLICT! {quick_hash} already maps to {hashes_found[quick_hash]}")
+            print(f'HASH CONFLICT! {quick_hash} already maps to {hashes_found[quick_hash]}')
         else:
             hashes_found[quick_hash] = url

--- a/scripts/print_quick_hashes.py
+++ b/scripts/print_quick_hashes.py
@@ -24,9 +24,7 @@ models_db = get_models_db()
 hashes_found = {}
 
 if args.diff_only:
-    print(
-        "Printing quick-hashes for only those URLs that do not match the configured quick-hash"
-    )
+    print("Printing quick-hashes for only those URLs that do not match the configured quick-hash")
 
 for model_type, models in models_db.items():
     print(f"{model_type} models:")
@@ -37,8 +35,6 @@ for model_type, models in models_db.items():
         if not args.diff_only or quick_hash != model_info.get("quick_hash"):
             print(f"{model_id} = {quick_hash}")
         if quick_hash in hashes_found:
-            print(
-                f"HASH CONFLICT! {quick_hash} already maps to {hashes_found[quick_hash]}"
-            )
+            print(f"HASH CONFLICT! {quick_hash} already maps to {hashes_found[quick_hash]}")
         else:
             hashes_found[quick_hash] = url

--- a/scripts/run_everything.py
+++ b/scripts/run_everything.py
@@ -16,9 +16,7 @@ parser.add_argument(
     default="Photograph of an astronaut riding a horse",
     help="Prompt to use for generating the image",
 )
-parser.add_argument(
-    "--seed", type=int, default=42, help="Seed to use for generating the image"
-)
+parser.add_argument("--seed", type=int, default=42, help="Seed to use for generating the image")
 parser.add_argument(
     "--models-dir",
     type=str,
@@ -39,7 +37,11 @@ parser.add_argument(
 parser.add_argument(
     "--exclude-models",
     default=set(),
-    help="Comma-separated list of model filenames (without spaces) to skip. Supports wildcards (without commas), for e.g. --exclude-models *.safetensors, or --exclude-models sd-1-4*",
+    help=(
+        "Comma-separated list of model filenames (without spaces) to skip. Supports"
+        " wildcards (without commas), for e.g. --exclude-models *.safetensors, or"
+        " --exclude-models sd-1-4*"
+    ),
 )
 parser.add_argument(
     "--samplers",
@@ -76,7 +78,11 @@ parser.add_argument(
     "--sizes",
     default="auto",
     type=str,
-    help="Comma-separated list of image sizes (width x height). No spaces. E.g. 512x512 or 512x512,1024x768. Defaults to what the model needs (512x512 or 768x768, if the model requires 768)",
+    help=(
+        "Comma-separated list of image sizes (width x height). No spaces. E.g. 512x512"
+        " or 512x512,1024x768. Defaults to what the model needs (512x512 or 768x768, if"
+        " the model requires 768)"
+    ),
 )
 parser.add_argument(
     "--device",
@@ -101,22 +107,14 @@ if args.samplers != "all":
 if args.exclude_samplers != set():
     args.exclude_samplers = set(args.exclude_samplers.split(","))
 if args.sizes != "auto":
-    args.sizes = [
-        tuple(map(lambda x: int(x), size.split("x"))) for size in args.sizes.split(",")
-    ]
+    args.sizes = [tuple(map(lambda x: int(x), size.split("x"))) for size in args.sizes.split(",")]
 
 # setup
 log.info("Starting..")
 from sdkit.generate.sampler import default_samplers, k_samplers
 from sdkit.models import load_model
 
-sd_models = set(
-    [
-        f
-        for f in os.listdir(args.models_dir)
-        if os.path.splitext(f)[1] in (".ckpt", ".safetensors")
-    ]
-)
+sd_models = set([f for f in os.listdir(args.models_dir) if os.path.splitext(f)[1] in (".ckpt", ".safetensors")])
 all_samplers = set(default_samplers.samplers.keys()) | set(k_samplers.samplers.keys())
 args.vram_usage_levels = args.vram_usage_levels.split(",")
 
@@ -133,9 +131,7 @@ vram_usage_levels_to_test = args.vram_usage_levels
 
 if args.init_image is not None:
     if not os.path.exists(args.init_image):
-        log.error(
-            f"Error! Could not an initial image at the path specified: {args.init_image}"
-        )
+        log.error(f"Error! Could not an initial image at the path specified: {args.init_image}")
         exit(1)
 
     if samplers_to_test != {"ddim"}:
@@ -185,9 +181,7 @@ def run_test():
         model_dir_path = os.path.join(args.out_dir, model_filename)
 
         if args.skip_completed and is_model_already_tested(model_dir_path):
-            log.info(
-                f"skipping model {model_filename} since it has already been processed at {model_dir_path}"
-            )
+            log.info(f"skipping model {model_filename} since it has already been processed at {model_dir_path}")
             continue
 
         for vram_usage_level in vram_usage_levels_to_test:
@@ -200,9 +194,7 @@ def run_test():
             os.makedirs(out_dir_path, exist_ok=True)
 
             try:
-                context.model_paths["stable-diffusion"] = os.path.join(
-                    args.models_dir, model_filename
-                )
+                context.model_paths["stable-diffusion"] = os.path.join(args.models_dir, model_filename)
                 load_model(context, "stable-diffusion", scan_model=False)
             except Exception as e:
                 log.exception(e)
@@ -259,9 +251,7 @@ def run_test():
             del context
 
 
-def run_samplers(
-    context, model_filename, out_dir_path, width, height, vram_usage_level
-):
+def run_samplers(context, model_filename, out_dir_path, width, height, vram_usage_level):
     from queue import Queue
     from threading import Event, Thread
 
@@ -269,13 +259,12 @@ def run_samplers(
         # setup
         img_path = os.path.join(out_dir_path, f"{sampler_name}_0.jpeg")
         if args.skip_completed and os.path.exists(img_path):
-            log.info(
-                f"skipping sampler {sampler_name} since it has already been processed at {img_path}"
-            )
+            log.info(f"skipping sampler {sampler_name} since it has already been processed at {img_path}")
             continue
 
         log.info(
-            f"Model: {model_filename}, Sampler: {sampler_name}, Size: {width}x{height}, VRAM Usage Level: {vram_usage_level}"
+            f"Model: {model_filename}, Sampler: {sampler_name}, Size: {width}x{height},"
+            f" VRAM Usage Level: {vram_usage_level}"
         )
 
         # start profiling
@@ -344,9 +333,7 @@ def profiling_thread(device, prof_thread_stop_event, ram_usage, vram_usage):
     import time
 
     while not prof_thread_stop_event.is_set():
-        cpu_used, ram_used, ram_total, vram_used, vram_total = get_device_usage(
-            device, log_info=args.live_perf
-        )
+        cpu_used, ram_used, ram_total, vram_used, vram_total = get_device_usage(device, log_info=args.live_perf)
 
         ram_usage.put(ram_used)
         vram_usage.put(vram_used)
@@ -358,9 +345,7 @@ def is_model_already_tested(out_dir_path):
     if not os.path.exists(out_dir_path):
         return False
 
-    sampler_files = list(
-        map(lambda x: os.path.join(out_dir_path, f"{x}_0.jpeg"), samplers_to_test)
-    )
+    sampler_files = list(map(lambda x: os.path.join(out_dir_path, f"{x}_0.jpeg"), samplers_to_test))
     images_exist = list(map(lambda x: os.path.exists(x), sampler_files))
     return all(images_exist)
 
@@ -368,9 +353,7 @@ def is_model_already_tested(out_dir_path):
 def get_min_size(model_path, default_size=512):
     model_info = get_model_info_from_db(quick_hash=hash_file_quick(model_path))
 
-    return (
-        model_info["metadata"]["min_size"] if model_info is not None else default_size
-    )
+    return model_info["metadata"]["min_size"] if model_info is not None else default_size
 
 
 def log_perf_results():
@@ -395,21 +378,13 @@ def log_perf_results():
 
     df["vram_tp90"] = df["vram_usage"].apply(lambda x: np.percentile(x, 90))
     df["vram_tp100"] = df["vram_usage"].apply(lambda x: np.percentile(x, 100))
-    df["vram_spike_test"] = (
-        abs((df["vram_tp100"] - df["vram_tp90"])) < 0.5
-    )  # okay with a spike of 500 MB
+    df["vram_spike_test"] = abs((df["vram_tp100"] - df["vram_tp90"])) < 0.5  # okay with a spike of 500 MB
     df["vram_tp90"] = df["vram_tp90"].apply(lambda x: f"{x:.1f}")
     df["overall_status"] = df["render_test"] & df["vram_spike_test"]
 
-    df["vram_spike_test"] = df["vram_spike_test"].apply(
-        lambda is_pass: "pass" if is_pass else "FAIL"
-    )
-    df["render_test"] = df["render_test"].apply(
-        lambda is_pass: "pass" if is_pass else "FAIL"
-    )
-    df["overall_status"] = df["overall_status"].apply(
-        lambda is_pass: "pass" if is_pass else "FAIL"
-    )
+    df["vram_spike_test"] = df["vram_spike_test"].apply(lambda is_pass: "pass" if is_pass else "FAIL")
+    df["render_test"] = df["render_test"].apply(lambda is_pass: "pass" if is_pass else "FAIL")
+    df["overall_status"] = df["overall_status"].apply(lambda is_pass: "pass" if is_pass else "FAIL")
 
     del df["vram_tp100"]
 

--- a/scripts/run_everything.py
+++ b/scripts/run_everything.py
@@ -2,10 +2,11 @@
 Runs the desired Stable Diffusion models against the desired samplers. Saves the output images
 to disk, along with the peak RAM and VRAM usage, as well as the sampling performance.
 """
+import argparse
 import os
 import time
-import argparse
-from sdkit.utils import log, get_device_usage
+
+from sdkit.utils import get_device_usage, log
 
 # args
 parser = argparse.ArgumentParser()
@@ -106,8 +107,8 @@ if args.sizes != "auto":
 
 # setup
 log.info("Starting..")
-from sdkit.models import load_model
 from sdkit.generate.sampler import default_samplers, k_samplers
+from sdkit.models import load_model
 
 sd_models = set(
     [
@@ -261,8 +262,8 @@ def run_test():
 def run_samplers(
     context, model_filename, out_dir_path, width, height, vram_usage_level
 ):
-    from threading import Thread, Event
     from queue import Queue
+    from threading import Event, Thread
 
     for sampler_name in samplers_to_test:
         # setup
@@ -373,9 +374,10 @@ def get_min_size(model_path, default_size=512):
 
 
 def log_perf_results():
-    import pandas as pd
-    import numpy as np
     from importlib.metadata import version
+
+    import numpy as np
+    import pandas as pd
 
     pd.set_option("display.max_rows", 1000)
 

--- a/scripts/run_everything.py
+++ b/scripts/run_everything.py
@@ -1,7 +1,7 @@
-'''
+"""
 Runs the desired Stable Diffusion models against the desired samplers. Saves the output images
 to disk, along with the peak RAM and VRAM usage, as well as the sampling performance.
-'''
+"""
 import os
 import time
 import argparse
@@ -9,59 +9,139 @@ from sdkit.utils import log, get_device_usage
 
 # args
 parser = argparse.ArgumentParser()
-parser.add_argument('--prompt', type=str, default="Photograph of an astronaut riding a horse", help="Prompt to use for generating the image")
-parser.add_argument('--seed', type=int, default=42, help="Seed to use for generating the image")
-parser.add_argument('--models-dir', type=str, required=True, help="Path to the directory containing the Stable Diffusion models")
-parser.add_argument('--out-dir', type=str, required=True, help="Path to the directory to save the generated images and test results")
-parser.add_argument('--models', default='all', help="Comma-separated list of model filenames (without spaces) to test. Default: all")
-parser.add_argument('--exclude-models', default=set(), help="Comma-separated list of model filenames (without spaces) to skip. Supports wildcards (without commas), for e.g. --exclude-models *.safetensors, or --exclude-models sd-1-4*")
-parser.add_argument('--samplers', default='all', help="Comma-separated list of sampler names (without spaces) to test. Default: all")
-parser.add_argument('--exclude-samplers', default=set(), help="Comma-separated list of sampler names (without spaces) to skip")
-parser.add_argument('--init-image', default=None, help="Path to an initial image to use. Only works with DDIM sampler (for now).")
-parser.add_argument('--vram-usage-levels', default='balanced', help="Comma-separated list of VRAM usage levels. Allowed values: low, balanced, high")
-parser.add_argument('--skip-completed', default=False, help="Skips a model or sampler if it has already been tested (i.e. an output image exists for it)")
-parser.add_argument('--steps', default=25, type=int, help="Number of inference steps to run for each sampler")
-parser.add_argument('--sizes', default='auto', type=str, help="Comma-separated list of image sizes (width x height). No spaces. E.g. 512x512 or 512x512,1024x768. Defaults to what the model needs (512x512 or 768x768, if the model requires 768)")
-parser.add_argument('--device', default='cuda:0', type=str, help="Specify the device to run on. E.g. cpu or cuda:0 or cuda:1 etc")
-parser.add_argument('--live-perf', action="store_true", help="Print the RAM and VRAM usage stats every few seconds")
+parser.add_argument(
+    "--prompt",
+    type=str,
+    default="Photograph of an astronaut riding a horse",
+    help="Prompt to use for generating the image",
+)
+parser.add_argument(
+    "--seed", type=int, default=42, help="Seed to use for generating the image"
+)
+parser.add_argument(
+    "--models-dir",
+    type=str,
+    required=True,
+    help="Path to the directory containing the Stable Diffusion models",
+)
+parser.add_argument(
+    "--out-dir",
+    type=str,
+    required=True,
+    help="Path to the directory to save the generated images and test results",
+)
+parser.add_argument(
+    "--models",
+    default="all",
+    help="Comma-separated list of model filenames (without spaces) to test. Default: all",
+)
+parser.add_argument(
+    "--exclude-models",
+    default=set(),
+    help="Comma-separated list of model filenames (without spaces) to skip. Supports wildcards (without commas), for e.g. --exclude-models *.safetensors, or --exclude-models sd-1-4*",
+)
+parser.add_argument(
+    "--samplers",
+    default="all",
+    help="Comma-separated list of sampler names (without spaces) to test. Default: all",
+)
+parser.add_argument(
+    "--exclude-samplers",
+    default=set(),
+    help="Comma-separated list of sampler names (without spaces) to skip",
+)
+parser.add_argument(
+    "--init-image",
+    default=None,
+    help="Path to an initial image to use. Only works with DDIM sampler (for now).",
+)
+parser.add_argument(
+    "--vram-usage-levels",
+    default="balanced",
+    help="Comma-separated list of VRAM usage levels. Allowed values: low, balanced, high",
+)
+parser.add_argument(
+    "--skip-completed",
+    default=False,
+    help="Skips a model or sampler if it has already been tested (i.e. an output image exists for it)",
+)
+parser.add_argument(
+    "--steps",
+    default=25,
+    type=int,
+    help="Number of inference steps to run for each sampler",
+)
+parser.add_argument(
+    "--sizes",
+    default="auto",
+    type=str,
+    help="Comma-separated list of image sizes (width x height). No spaces. E.g. 512x512 or 512x512,1024x768. Defaults to what the model needs (512x512 or 768x768, if the model requires 768)",
+)
+parser.add_argument(
+    "--device",
+    default="cuda:0",
+    type=str,
+    help="Specify the device to run on. E.g. cpu or cuda:0 or cuda:1 etc",
+)
+parser.add_argument(
+    "--live-perf",
+    action="store_true",
+    help="Print the RAM and VRAM usage stats every few seconds",
+)
 parser.set_defaults(live_perf=False)
 args = parser.parse_args()
 
-if args.models != 'all': args.models = set(args.models.split(','))
-if args.exclude_models != set() and '*' not in args.exclude_models: args.exclude_models = set(args.exclude_models.split(','))
-if args.samplers != 'all': args.samplers = set(args.samplers.split(','))
-if args.exclude_samplers != set(): args.exclude_samplers = set(args.exclude_samplers.split(','))
-if args.sizes != 'auto': args.sizes = [tuple(map(lambda x: int(x), size.split('x'))) for size in args.sizes.split(',')]
+if args.models != "all":
+    args.models = set(args.models.split(","))
+if args.exclude_models != set() and "*" not in args.exclude_models:
+    args.exclude_models = set(args.exclude_models.split(","))
+if args.samplers != "all":
+    args.samplers = set(args.samplers.split(","))
+if args.exclude_samplers != set():
+    args.exclude_samplers = set(args.exclude_samplers.split(","))
+if args.sizes != "auto":
+    args.sizes = [
+        tuple(map(lambda x: int(x), size.split("x"))) for size in args.sizes.split(",")
+    ]
 
 # setup
-log.info('Starting..')
+log.info("Starting..")
 from sdkit.models import load_model
 from sdkit.generate.sampler import default_samplers, k_samplers
 
-sd_models = set([f for f in os.listdir(args.models_dir) if os.path.splitext(f)[1] in ('.ckpt', '.safetensors')])
+sd_models = set(
+    [
+        f
+        for f in os.listdir(args.models_dir)
+        if os.path.splitext(f)[1] in (".ckpt", ".safetensors")
+    ]
+)
 all_samplers = set(default_samplers.samplers.keys()) | set(k_samplers.samplers.keys())
-args.vram_usage_levels = args.vram_usage_levels.split(',')
+args.vram_usage_levels = args.vram_usage_levels.split(",")
 
-if isinstance(args.exclude_models, str) and '*' in args.exclude_models:
+if isinstance(args.exclude_models, str) and "*" in args.exclude_models:
     import fnmatch
+
     args.exclude_models = set(fnmatch.filter(sd_models, args.exclude_models))
 
-models_to_test = sd_models if args.models == 'all' else args.models
+models_to_test = sd_models if args.models == "all" else args.models
 models_to_test -= args.exclude_models
-samplers_to_test = all_samplers if args.samplers == 'all' else args.samplers
+samplers_to_test = all_samplers if args.samplers == "all" else args.samplers
 samplers_to_test -= args.exclude_samplers
 vram_usage_levels_to_test = args.vram_usage_levels
 
 if args.init_image is not None:
     if not os.path.exists(args.init_image):
-        log.error(f'Error! Could not an initial image at the path specified: {args.init_image}')
+        log.error(
+            f"Error! Could not an initial image at the path specified: {args.init_image}"
+        )
         exit(1)
 
-    if samplers_to_test != {'ddim'}:
+    if samplers_to_test != {"ddim"}:
         log.error('We only support the "ddim" sampler for img2img right now!')
         exit(1)
 
-    all_samplers = {'ddim'}
+    all_samplers = {"ddim"}
 
 # setup the test
 from sdkit import Context
@@ -69,19 +149,34 @@ from sdkit.generate import generate_images
 from sdkit.models import get_model_info_from_db
 from sdkit.utils import hash_file_quick
 
-perf_results = [['model_filename', 'vram_usage_level', 'sampler_name', 'max_ram (GB)', 'max_vram (GB)', 'image_size', 'time_taken (s)', 'speed (it/s)', 'render_test', 'ram_usage', 'vram_usage']]
-perf_results_file = f'perf_results_{time.time()}.csv'
+perf_results = [
+    [
+        "model_filename",
+        "vram_usage_level",
+        "sampler_name",
+        "max_ram (GB)",
+        "max_vram (GB)",
+        "image_size",
+        "time_taken (s)",
+        "speed (it/s)",
+        "render_test",
+        "ram_usage",
+        "vram_usage",
+    ]
+]
+perf_results_file = f"perf_results_{time.time()}.csv"
 
 # print test info
-log.info('---')
-log.info(f'Models actually being tested: {models_to_test}')
-log.info(f'Samplers actually being tested: {samplers_to_test}')
-log.info(f'VRAM usage levels being tested: {vram_usage_levels_to_test}')
-log.info(f'Image sizes being tested: {args.sizes}')
-log.info('---')
-log.info(f'Available models: {sd_models}')
-log.info(f'Available samplers: {all_samplers}')
-log.info('---')
+log.info("---")
+log.info(f"Models actually being tested: {models_to_test}")
+log.info(f"Samplers actually being tested: {samplers_to_test}")
+log.info(f"VRAM usage levels being tested: {vram_usage_levels_to_test}")
+log.info(f"Image sizes being tested: {args.sizes}")
+log.info("---")
+log.info(f"Available models: {sd_models}")
+log.info(f"Available samplers: {all_samplers}")
+log.info("---")
+
 
 # run the test
 def run_test():
@@ -89,7 +184,9 @@ def run_test():
         model_dir_path = os.path.join(args.out_dir, model_filename)
 
         if args.skip_completed and is_model_already_tested(model_dir_path):
-            log.info(f'skipping model {model_filename} since it has already been processed at {model_dir_path}')
+            log.info(
+                f"skipping model {model_filename} since it has already been processed at {model_dir_path}"
+            )
             continue
 
         for vram_usage_level in vram_usage_levels_to_test:
@@ -102,57 +199,97 @@ def run_test():
             os.makedirs(out_dir_path, exist_ok=True)
 
             try:
-                context.model_paths['stable-diffusion'] = os.path.join(args.models_dir, model_filename)
-                load_model(context, 'stable-diffusion', scan_model=False)
+                context.model_paths["stable-diffusion"] = os.path.join(
+                    args.models_dir, model_filename
+                )
+                load_model(context, "stable-diffusion", scan_model=False)
             except Exception as e:
                 log.exception(e)
-                perf_results.append([model_filename, vram_usage_level, 'n/a', 'n/a', 'n/a', 'n/a', 'n/a', 'n/a', False, [], []])
+                perf_results.append(
+                    [
+                        model_filename,
+                        vram_usage_level,
+                        "n/a",
+                        "n/a",
+                        "n/a",
+                        "n/a",
+                        "n/a",
+                        "n/a",
+                        False,
+                        [],
+                        [],
+                    ]
+                )
                 log_perf_results()
                 continue
 
-
             # run a warm-up, before running the actual samplers
-            log.info('Warming up..')
+            log.info("Warming up..")
             try:
-                generate_images(context, prompt='Photograph of an astronaut riding a horse', num_inference_steps=10, seed=42, width=512, height=512, sampler_name='euler_a')
+                generate_images(
+                    context,
+                    prompt="Photograph of an astronaut riding a horse",
+                    num_inference_steps=10,
+                    seed=42,
+                    width=512,
+                    height=512,
+                    sampler_name="euler_a",
+                )
             except:
                 pass
 
-            if args.sizes == 'auto':
-                min_size = get_min_size(context.model_paths['stable-diffusion'])
+            if args.sizes == "auto":
+                min_size = get_min_size(context.model_paths["stable-diffusion"])
                 sizes = [(min_size, min_size)]
             else:
                 sizes = args.sizes
 
             # run the actual test
             for width, height in sizes:
-                run_samplers(context, model_filename, out_dir_path, width, height, vram_usage_level)
+                run_samplers(
+                    context,
+                    model_filename,
+                    out_dir_path,
+                    width,
+                    height,
+                    vram_usage_level,
+                )
 
             del context
 
-def run_samplers(context, model_filename, out_dir_path, width, height, vram_usage_level):
+
+def run_samplers(
+    context, model_filename, out_dir_path, width, height, vram_usage_level
+):
     from threading import Thread, Event
     from queue import Queue
 
     for sampler_name in samplers_to_test:
         # setup
-        img_path = os.path.join(out_dir_path, f'{sampler_name}_0.jpeg')
+        img_path = os.path.join(out_dir_path, f"{sampler_name}_0.jpeg")
         if args.skip_completed and os.path.exists(img_path):
-            log.info(f'skipping sampler {sampler_name} since it has already been processed at {img_path}')
+            log.info(
+                f"skipping sampler {sampler_name} since it has already been processed at {img_path}"
+            )
             continue
 
-        log.info(f'Model: {model_filename}, Sampler: {sampler_name}, Size: {width}x{height}, VRAM Usage Level: {vram_usage_level}')
+        log.info(
+            f"Model: {model_filename}, Sampler: {sampler_name}, Size: {width}x{height}, VRAM Usage Level: {vram_usage_level}"
+        )
 
         # start profiling
         prof_thread_stop_event = Event()
         ram_usage = Queue()
         vram_usage = Queue()
-        prof_thread = Thread(target=profiling_thread, kwargs={
-            'device': context.device,
-            'prof_thread_stop_event': prof_thread_stop_event,
-            'ram_usage': ram_usage,
-            'vram_usage': vram_usage,
-        })
+        prof_thread = Thread(
+            target=profiling_thread,
+            kwargs={
+                "device": context.device,
+                "prof_thread_stop_event": prof_thread_stop_event,
+                "ram_usage": ram_usage,
+                "vram_usage": vram_usage,
+            },
+        )
         prof_thread.start()
 
         t, speed = time.time(), 0
@@ -164,7 +301,8 @@ def run_samplers(context, model_filename, out_dir_path, width, height, vram_usag
                 prompt=args.prompt,
                 seed=args.seed,
                 num_inference_steps=args.steps,
-                width=width, height=height,
+                width=width,
+                height=height,
                 sampler_name=sampler_name,
                 init_image=args.init_image,
             )
@@ -182,75 +320,108 @@ def run_samplers(context, model_filename, out_dir_path, width, height, vram_usag
             prof_thread_stop_event.set()
             prof_thread.join()
 
-        perf_results.append([model_filename, vram_usage_level, sampler_name, f'{max(ram_usage.queue):.1f}', f'{max(vram_usage.queue):.1f}', f'{width}x{height}', f'{t:.1f}', f'{speed:.1f}', render_success, list(ram_usage.queue), list(vram_usage.queue)])
+        perf_results.append(
+            [
+                model_filename,
+                vram_usage_level,
+                sampler_name,
+                f"{max(ram_usage.queue):.1f}",
+                f"{max(vram_usage.queue):.1f}",
+                f"{width}x{height}",
+                f"{t:.1f}",
+                f"{speed:.1f}",
+                render_success,
+                list(ram_usage.queue),
+                list(vram_usage.queue),
+            ]
+        )
 
         log_perf_results()
+
 
 def profiling_thread(device, prof_thread_stop_event, ram_usage, vram_usage):
     import time
 
     while not prof_thread_stop_event.is_set():
-        cpu_used, ram_used, ram_total, vram_used, vram_total = get_device_usage(device, log_info=args.live_perf)
+        cpu_used, ram_used, ram_total, vram_used, vram_total = get_device_usage(
+            device, log_info=args.live_perf
+        )
 
         ram_usage.put(ram_used)
         vram_usage.put(vram_used)
 
         time.sleep(1)
 
+
 def is_model_already_tested(out_dir_path):
     if not os.path.exists(out_dir_path):
         return False
 
-    sampler_files = list(map(lambda x: os.path.join(out_dir_path, f'{x}_0.jpeg'), samplers_to_test))
+    sampler_files = list(
+        map(lambda x: os.path.join(out_dir_path, f"{x}_0.jpeg"), samplers_to_test)
+    )
     images_exist = list(map(lambda x: os.path.exists(x), sampler_files))
     return all(images_exist)
+
 
 def get_min_size(model_path, default_size=512):
     model_info = get_model_info_from_db(quick_hash=hash_file_quick(model_path))
 
-    return model_info['metadata']['min_size'] if model_info is not None else default_size
+    return (
+        model_info["metadata"]["min_size"] if model_info is not None else default_size
+    )
+
 
 def log_perf_results():
     import pandas as pd
     import numpy as np
     from importlib.metadata import version
 
-    pd.set_option('display.max_rows', 1000)
+    pd.set_option("display.max_rows", 1000)
 
-    print('\n-- Performance summary --')
+    print("\n-- Performance summary --")
     print(f"sdkit version: {version('sdkit')}")
     print(f"stable-diffusion-sdkit version: {version('stable-diffusion-sdkit')}")
-    print(f'Device: {args.device}')
-    print(f'Num inference steps: {args.steps}')
-    print('')
+    print(f"Device: {args.device}")
+    print(f"Num inference steps: {args.steps}")
+    print("")
 
     df = pd.DataFrame(data=perf_results)
     df = df.rename(columns=df.iloc[0]).drop(df.index[0])
-    df = df.sort_values(by=['image_size', 'model_filename'], ascending=False)
+    df = df.sort_values(by=["image_size", "model_filename"], ascending=False)
     df = df.reset_index(drop=True)
 
-    df['vram_tp90'] = df['vram_usage'].apply(lambda x: np.percentile(x, 90))
-    df['vram_tp100'] = df['vram_usage'].apply(lambda x: np.percentile(x, 100))
-    df['vram_spike_test'] = abs((df['vram_tp100'] - df['vram_tp90'])) < 0.5 # okay with a spike of 500 MB
-    df['vram_tp90'] = df['vram_tp90'].apply(lambda x: f'{x:.1f}')
-    df['overall_status'] = df['render_test'] & df['vram_spike_test']
+    df["vram_tp90"] = df["vram_usage"].apply(lambda x: np.percentile(x, 90))
+    df["vram_tp100"] = df["vram_usage"].apply(lambda x: np.percentile(x, 100))
+    df["vram_spike_test"] = (
+        abs((df["vram_tp100"] - df["vram_tp90"])) < 0.5
+    )  # okay with a spike of 500 MB
+    df["vram_tp90"] = df["vram_tp90"].apply(lambda x: f"{x:.1f}")
+    df["overall_status"] = df["render_test"] & df["vram_spike_test"]
 
-    df['vram_spike_test'] = df['vram_spike_test'].apply(lambda is_pass: 'pass' if is_pass else 'FAIL')
-    df['render_test'] = df['render_test'].apply(lambda is_pass: 'pass' if is_pass else 'FAIL')
-    df['overall_status'] = df['overall_status'].apply(lambda is_pass: 'pass' if is_pass else 'FAIL')
+    df["vram_spike_test"] = df["vram_spike_test"].apply(
+        lambda is_pass: "pass" if is_pass else "FAIL"
+    )
+    df["render_test"] = df["render_test"].apply(
+        lambda is_pass: "pass" if is_pass else "FAIL"
+    )
+    df["overall_status"] = df["overall_status"].apply(
+        lambda is_pass: "pass" if is_pass else "FAIL"
+    )
 
-    del df['vram_tp100']
+    del df["vram_tp100"]
 
     out_file = os.path.join(args.out_dir, perf_results_file)
     df.to_csv(out_file, index=False)
 
     # print the summary
-    del df['vram_usage']
-    del df['ram_usage']
+    del df["vram_usage"]
+    del df["ram_usage"]
 
     print(df)
-    print('')
+    print("")
 
-    print(f'Written the performance summary to {out_file}\n')
+    print(f"Written the performance summary to {out_file}\n")
+
 
 run_test()

--- a/scripts/run_everything.py
+++ b/scripts/run_everything.py
@@ -1,144 +1,67 @@
-"""
+'''
 Runs the desired Stable Diffusion models against the desired samplers. Saves the output images
 to disk, along with the peak RAM and VRAM usage, as well as the sampling performance.
-"""
-import argparse
+'''
 import os
 import time
-
-from sdkit.utils import get_device_usage, log
+import argparse
+from sdkit.utils import log, get_device_usage
 
 # args
 parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--prompt",
-    type=str,
-    default="Photograph of an astronaut riding a horse",
-    help="Prompt to use for generating the image",
-)
-parser.add_argument("--seed", type=int, default=42, help="Seed to use for generating the image")
-parser.add_argument(
-    "--models-dir",
-    type=str,
-    required=True,
-    help="Path to the directory containing the Stable Diffusion models",
-)
-parser.add_argument(
-    "--out-dir",
-    type=str,
-    required=True,
-    help="Path to the directory to save the generated images and test results",
-)
-parser.add_argument(
-    "--models",
-    default="all",
-    help="Comma-separated list of model filenames (without spaces) to test. Default: all",
-)
-parser.add_argument(
-    "--exclude-models",
-    default=set(),
-    help=(
-        "Comma-separated list of model filenames (without spaces) to skip. Supports"
-        " wildcards (without commas), for e.g. --exclude-models *.safetensors, or"
-        " --exclude-models sd-1-4*"
-    ),
-)
-parser.add_argument(
-    "--samplers",
-    default="all",
-    help="Comma-separated list of sampler names (without spaces) to test. Default: all",
-)
-parser.add_argument(
-    "--exclude-samplers",
-    default=set(),
-    help="Comma-separated list of sampler names (without spaces) to skip",
-)
-parser.add_argument(
-    "--init-image",
-    default=None,
-    help="Path to an initial image to use. Only works with DDIM sampler (for now).",
-)
-parser.add_argument(
-    "--vram-usage-levels",
-    default="balanced",
-    help="Comma-separated list of VRAM usage levels. Allowed values: low, balanced, high",
-)
-parser.add_argument(
-    "--skip-completed",
-    default=False,
-    help="Skips a model or sampler if it has already been tested (i.e. an output image exists for it)",
-)
-parser.add_argument(
-    "--steps",
-    default=25,
-    type=int,
-    help="Number of inference steps to run for each sampler",
-)
-parser.add_argument(
-    "--sizes",
-    default="auto",
-    type=str,
-    help=(
-        "Comma-separated list of image sizes (width x height). No spaces. E.g. 512x512"
-        " or 512x512,1024x768. Defaults to what the model needs (512x512 or 768x768, if"
-        " the model requires 768)"
-    ),
-)
-parser.add_argument(
-    "--device",
-    default="cuda:0",
-    type=str,
-    help="Specify the device to run on. E.g. cpu or cuda:0 or cuda:1 etc",
-)
-parser.add_argument(
-    "--live-perf",
-    action="store_true",
-    help="Print the RAM and VRAM usage stats every few seconds",
-)
+parser.add_argument('--prompt', type=str, default="Photograph of an astronaut riding a horse", help="Prompt to use for generating the image")
+parser.add_argument('--seed', type=int, default=42, help="Seed to use for generating the image")
+parser.add_argument('--models-dir', type=str, required=True, help="Path to the directory containing the Stable Diffusion models")
+parser.add_argument('--out-dir', type=str, required=True, help="Path to the directory to save the generated images and test results")
+parser.add_argument('--models', default='all', help="Comma-separated list of model filenames (without spaces) to test. Default: all")
+parser.add_argument('--exclude-models', default=set(), help="Comma-separated list of model filenames (without spaces) to skip. Supports wildcards (without commas), for e.g. --exclude-models *.safetensors, or --exclude-models sd-1-4*")
+parser.add_argument('--samplers', default='all', help="Comma-separated list of sampler names (without spaces) to test. Default: all")
+parser.add_argument('--exclude-samplers', default=set(), help="Comma-separated list of sampler names (without spaces) to skip")
+parser.add_argument('--init-image', default=None, help="Path to an initial image to use. Only works with DDIM sampler (for now).")
+parser.add_argument('--vram-usage-levels', default='balanced', help="Comma-separated list of VRAM usage levels. Allowed values: low, balanced, high")
+parser.add_argument('--skip-completed', default=False, help="Skips a model or sampler if it has already been tested (i.e. an output image exists for it)")
+parser.add_argument('--steps', default=25, type=int, help="Number of inference steps to run for each sampler")
+parser.add_argument('--sizes', default='auto', type=str, help="Comma-separated list of image sizes (width x height). No spaces. E.g. 512x512 or 512x512,1024x768. Defaults to what the model needs (512x512 or 768x768, if the model requires 768)")
+parser.add_argument('--device', default='cuda:0', type=str, help="Specify the device to run on. E.g. cpu or cuda:0 or cuda:1 etc")
+parser.add_argument('--live-perf', action="store_true", help="Print the RAM and VRAM usage stats every few seconds")
 parser.set_defaults(live_perf=False)
 args = parser.parse_args()
 
-if args.models != "all":
-    args.models = set(args.models.split(","))
-if args.exclude_models != set() and "*" not in args.exclude_models:
-    args.exclude_models = set(args.exclude_models.split(","))
-if args.samplers != "all":
-    args.samplers = set(args.samplers.split(","))
-if args.exclude_samplers != set():
-    args.exclude_samplers = set(args.exclude_samplers.split(","))
-if args.sizes != "auto":
-    args.sizes = [tuple(map(lambda x: int(x), size.split("x"))) for size in args.sizes.split(",")]
+if args.models != 'all': args.models = set(args.models.split(','))
+if args.exclude_models != set() and '*' not in args.exclude_models: args.exclude_models = set(args.exclude_models.split(','))
+if args.samplers != 'all': args.samplers = set(args.samplers.split(','))
+if args.exclude_samplers != set(): args.exclude_samplers = set(args.exclude_samplers.split(','))
+if args.sizes != 'auto': args.sizes = [tuple(map(lambda x: int(x), size.split('x'))) for size in args.sizes.split(',')]
 
 # setup
-log.info("Starting..")
-from sdkit.generate.sampler import default_samplers, k_samplers
+log.info('Starting..')
 from sdkit.models import load_model
+from sdkit.generate.sampler import default_samplers, k_samplers
 
-sd_models = set([f for f in os.listdir(args.models_dir) if os.path.splitext(f)[1] in (".ckpt", ".safetensors")])
+sd_models = set([f for f in os.listdir(args.models_dir) if os.path.splitext(f)[1] in ('.ckpt', '.safetensors')])
 all_samplers = set(default_samplers.samplers.keys()) | set(k_samplers.samplers.keys())
-args.vram_usage_levels = args.vram_usage_levels.split(",")
+args.vram_usage_levels = args.vram_usage_levels.split(',')
 
-if isinstance(args.exclude_models, str) and "*" in args.exclude_models:
+if isinstance(args.exclude_models, str) and '*' in args.exclude_models:
     import fnmatch
-
     args.exclude_models = set(fnmatch.filter(sd_models, args.exclude_models))
 
-models_to_test = sd_models if args.models == "all" else args.models
+models_to_test = sd_models if args.models == 'all' else args.models
 models_to_test -= args.exclude_models
-samplers_to_test = all_samplers if args.samplers == "all" else args.samplers
+samplers_to_test = all_samplers if args.samplers == 'all' else args.samplers
 samplers_to_test -= args.exclude_samplers
 vram_usage_levels_to_test = args.vram_usage_levels
 
 if args.init_image is not None:
     if not os.path.exists(args.init_image):
-        log.error(f"Error! Could not an initial image at the path specified: {args.init_image}")
+        log.error(f'Error! Could not an initial image at the path specified: {args.init_image}')
         exit(1)
 
-    if samplers_to_test != {"ddim"}:
+    if samplers_to_test != {'ddim'}:
         log.error('We only support the "ddim" sampler for img2img right now!')
         exit(1)
 
-    all_samplers = {"ddim"}
+    all_samplers = {'ddim'}
 
 # setup the test
 from sdkit import Context
@@ -146,34 +69,19 @@ from sdkit.generate import generate_images
 from sdkit.models import get_model_info_from_db
 from sdkit.utils import hash_file_quick
 
-perf_results = [
-    [
-        "model_filename",
-        "vram_usage_level",
-        "sampler_name",
-        "max_ram (GB)",
-        "max_vram (GB)",
-        "image_size",
-        "time_taken (s)",
-        "speed (it/s)",
-        "render_test",
-        "ram_usage",
-        "vram_usage",
-    ]
-]
-perf_results_file = f"perf_results_{time.time()}.csv"
+perf_results = [['model_filename', 'vram_usage_level', 'sampler_name', 'max_ram (GB)', 'max_vram (GB)', 'image_size', 'time_taken (s)', 'speed (it/s)', 'render_test', 'ram_usage', 'vram_usage']]
+perf_results_file = f'perf_results_{time.time()}.csv'
 
 # print test info
-log.info("---")
-log.info(f"Models actually being tested: {models_to_test}")
-log.info(f"Samplers actually being tested: {samplers_to_test}")
-log.info(f"VRAM usage levels being tested: {vram_usage_levels_to_test}")
-log.info(f"Image sizes being tested: {args.sizes}")
-log.info("---")
-log.info(f"Available models: {sd_models}")
-log.info(f"Available samplers: {all_samplers}")
-log.info("---")
-
+log.info('---')
+log.info(f'Models actually being tested: {models_to_test}')
+log.info(f'Samplers actually being tested: {samplers_to_test}')
+log.info(f'VRAM usage levels being tested: {vram_usage_levels_to_test}')
+log.info(f'Image sizes being tested: {args.sizes}')
+log.info('---')
+log.info(f'Available models: {sd_models}')
+log.info(f'Available samplers: {all_samplers}')
+log.info('---')
 
 # run the test
 def run_test():
@@ -181,7 +89,7 @@ def run_test():
         model_dir_path = os.path.join(args.out_dir, model_filename)
 
         if args.skip_completed and is_model_already_tested(model_dir_path):
-            log.info(f"skipping model {model_filename} since it has already been processed at {model_dir_path}")
+            log.info(f'skipping model {model_filename} since it has already been processed at {model_dir_path}')
             continue
 
         for vram_usage_level in vram_usage_levels_to_test:
@@ -194,92 +102,57 @@ def run_test():
             os.makedirs(out_dir_path, exist_ok=True)
 
             try:
-                context.model_paths["stable-diffusion"] = os.path.join(args.models_dir, model_filename)
-                load_model(context, "stable-diffusion", scan_model=False)
+                context.model_paths['stable-diffusion'] = os.path.join(args.models_dir, model_filename)
+                load_model(context, 'stable-diffusion', scan_model=False)
             except Exception as e:
                 log.exception(e)
-                perf_results.append(
-                    [
-                        model_filename,
-                        vram_usage_level,
-                        "n/a",
-                        "n/a",
-                        "n/a",
-                        "n/a",
-                        "n/a",
-                        "n/a",
-                        False,
-                        [],
-                        [],
-                    ]
-                )
+                perf_results.append([model_filename, vram_usage_level, 'n/a', 'n/a', 'n/a', 'n/a', 'n/a', 'n/a', False, [], []])
                 log_perf_results()
                 continue
 
+
             # run a warm-up, before running the actual samplers
-            log.info("Warming up..")
+            log.info('Warming up..')
             try:
-                generate_images(
-                    context,
-                    prompt="Photograph of an astronaut riding a horse",
-                    num_inference_steps=10,
-                    seed=42,
-                    width=512,
-                    height=512,
-                    sampler_name="euler_a",
-                )
+                generate_images(context, prompt='Photograph of an astronaut riding a horse', num_inference_steps=10, seed=42, width=512, height=512, sampler_name='euler_a')
             except:
                 pass
 
-            if args.sizes == "auto":
-                min_size = get_min_size(context.model_paths["stable-diffusion"])
+            if args.sizes == 'auto':
+                min_size = get_min_size(context.model_paths['stable-diffusion'])
                 sizes = [(min_size, min_size)]
             else:
                 sizes = args.sizes
 
             # run the actual test
             for width, height in sizes:
-                run_samplers(
-                    context,
-                    model_filename,
-                    out_dir_path,
-                    width,
-                    height,
-                    vram_usage_level,
-                )
+                run_samplers(context, model_filename, out_dir_path, width, height, vram_usage_level)
 
             del context
 
-
 def run_samplers(context, model_filename, out_dir_path, width, height, vram_usage_level):
+    from threading import Thread, Event
     from queue import Queue
-    from threading import Event, Thread
 
     for sampler_name in samplers_to_test:
         # setup
-        img_path = os.path.join(out_dir_path, f"{sampler_name}_0.jpeg")
+        img_path = os.path.join(out_dir_path, f'{sampler_name}_0.jpeg')
         if args.skip_completed and os.path.exists(img_path):
-            log.info(f"skipping sampler {sampler_name} since it has already been processed at {img_path}")
+            log.info(f'skipping sampler {sampler_name} since it has already been processed at {img_path}')
             continue
 
-        log.info(
-            f"Model: {model_filename}, Sampler: {sampler_name}, Size: {width}x{height},"
-            f" VRAM Usage Level: {vram_usage_level}"
-        )
+        log.info(f'Model: {model_filename}, Sampler: {sampler_name}, Size: {width}x{height}, VRAM Usage Level: {vram_usage_level}')
 
         # start profiling
         prof_thread_stop_event = Event()
         ram_usage = Queue()
         vram_usage = Queue()
-        prof_thread = Thread(
-            target=profiling_thread,
-            kwargs={
-                "device": context.device,
-                "prof_thread_stop_event": prof_thread_stop_event,
-                "ram_usage": ram_usage,
-                "vram_usage": vram_usage,
-            },
-        )
+        prof_thread = Thread(target=profiling_thread, kwargs={
+            'device': context.device,
+            'prof_thread_stop_event': prof_thread_stop_event,
+            'ram_usage': ram_usage,
+            'vram_usage': vram_usage,
+        })
         prof_thread.start()
 
         t, speed = time.time(), 0
@@ -291,8 +164,7 @@ def run_samplers(context, model_filename, out_dir_path, width, height, vram_usag
                 prompt=args.prompt,
                 seed=args.seed,
                 num_inference_steps=args.steps,
-                width=width,
-                height=height,
+                width=width, height=height,
                 sampler_name=sampler_name,
                 init_image=args.init_image,
             )
@@ -310,24 +182,9 @@ def run_samplers(context, model_filename, out_dir_path, width, height, vram_usag
             prof_thread_stop_event.set()
             prof_thread.join()
 
-        perf_results.append(
-            [
-                model_filename,
-                vram_usage_level,
-                sampler_name,
-                f"{max(ram_usage.queue):.1f}",
-                f"{max(vram_usage.queue):.1f}",
-                f"{width}x{height}",
-                f"{t:.1f}",
-                f"{speed:.1f}",
-                render_success,
-                list(ram_usage.queue),
-                list(vram_usage.queue),
-            ]
-        )
+        perf_results.append([model_filename, vram_usage_level, sampler_name, f'{max(ram_usage.queue):.1f}', f'{max(vram_usage.queue):.1f}', f'{width}x{height}', f'{t:.1f}', f'{speed:.1f}', render_success, list(ram_usage.queue), list(vram_usage.queue)])
 
         log_perf_results()
-
 
 def profiling_thread(device, prof_thread_stop_event, ram_usage, vram_usage):
     import time
@@ -340,65 +197,60 @@ def profiling_thread(device, prof_thread_stop_event, ram_usage, vram_usage):
 
         time.sleep(1)
 
-
 def is_model_already_tested(out_dir_path):
     if not os.path.exists(out_dir_path):
         return False
 
-    sampler_files = list(map(lambda x: os.path.join(out_dir_path, f"{x}_0.jpeg"), samplers_to_test))
+    sampler_files = list(map(lambda x: os.path.join(out_dir_path, f'{x}_0.jpeg'), samplers_to_test))
     images_exist = list(map(lambda x: os.path.exists(x), sampler_files))
     return all(images_exist)
-
 
 def get_min_size(model_path, default_size=512):
     model_info = get_model_info_from_db(quick_hash=hash_file_quick(model_path))
 
-    return model_info["metadata"]["min_size"] if model_info is not None else default_size
-
+    return model_info['metadata']['min_size'] if model_info is not None else default_size
 
 def log_perf_results():
+    import pandas as pd
+    import numpy as np
     from importlib.metadata import version
 
-    import numpy as np
-    import pandas as pd
+    pd.set_option('display.max_rows', 1000)
 
-    pd.set_option("display.max_rows", 1000)
-
-    print("\n-- Performance summary --")
+    print('\n-- Performance summary --')
     print(f"sdkit version: {version('sdkit')}")
     print(f"stable-diffusion-sdkit version: {version('stable-diffusion-sdkit')}")
-    print(f"Device: {args.device}")
-    print(f"Num inference steps: {args.steps}")
-    print("")
+    print(f'Device: {args.device}')
+    print(f'Num inference steps: {args.steps}')
+    print('')
 
     df = pd.DataFrame(data=perf_results)
     df = df.rename(columns=df.iloc[0]).drop(df.index[0])
-    df = df.sort_values(by=["image_size", "model_filename"], ascending=False)
+    df = df.sort_values(by=['image_size', 'model_filename'], ascending=False)
     df = df.reset_index(drop=True)
 
-    df["vram_tp90"] = df["vram_usage"].apply(lambda x: np.percentile(x, 90))
-    df["vram_tp100"] = df["vram_usage"].apply(lambda x: np.percentile(x, 100))
-    df["vram_spike_test"] = abs((df["vram_tp100"] - df["vram_tp90"])) < 0.5  # okay with a spike of 500 MB
-    df["vram_tp90"] = df["vram_tp90"].apply(lambda x: f"{x:.1f}")
-    df["overall_status"] = df["render_test"] & df["vram_spike_test"]
+    df['vram_tp90'] = df['vram_usage'].apply(lambda x: np.percentile(x, 90))
+    df['vram_tp100'] = df['vram_usage'].apply(lambda x: np.percentile(x, 100))
+    df['vram_spike_test'] = abs((df['vram_tp100'] - df['vram_tp90'])) < 0.5 # okay with a spike of 500 MB
+    df['vram_tp90'] = df['vram_tp90'].apply(lambda x: f'{x:.1f}')
+    df['overall_status'] = df['render_test'] & df['vram_spike_test']
 
-    df["vram_spike_test"] = df["vram_spike_test"].apply(lambda is_pass: "pass" if is_pass else "FAIL")
-    df["render_test"] = df["render_test"].apply(lambda is_pass: "pass" if is_pass else "FAIL")
-    df["overall_status"] = df["overall_status"].apply(lambda is_pass: "pass" if is_pass else "FAIL")
+    df['vram_spike_test'] = df['vram_spike_test'].apply(lambda is_pass: 'pass' if is_pass else 'FAIL')
+    df['render_test'] = df['render_test'].apply(lambda is_pass: 'pass' if is_pass else 'FAIL')
+    df['overall_status'] = df['overall_status'].apply(lambda is_pass: 'pass' if is_pass else 'FAIL')
 
-    del df["vram_tp100"]
+    del df['vram_tp100']
 
     out_file = os.path.join(args.out_dir, perf_results_file)
     df.to_csv(out_file, index=False)
 
     # print the summary
-    del df["vram_usage"]
-    del df["ram_usage"]
+    del df['vram_usage']
+    del df['ram_usage']
 
     print(df)
-    print("")
+    print('')
 
-    print(f"Written the performance summary to {out_file}\n")
-
+    print(f'Written the performance summary to {out_file}\n')
 
 run_test()

--- a/scripts/run_everything.py
+++ b/scripts/run_everything.py
@@ -2,10 +2,11 @@
 Runs the desired Stable Diffusion models against the desired samplers. Saves the output images
 to disk, along with the peak RAM and VRAM usage, as well as the sampling performance.
 """
+import argparse
 import os
 import time
-import argparse
-from sdkit.utils import log, get_device_usage
+
+from sdkit.utils import get_device_usage, log
 
 # args
 parser = argparse.ArgumentParser()
@@ -76,8 +77,8 @@ if args.sizes != "auto":
 
 # setup
 log.info("Starting..")
-from sdkit.models import load_model
 from sdkit.generate.sampler import default_samplers, k_samplers
+from sdkit.models import load_model
 
 sd_models = set([f for f in os.listdir(args.models_dir) if os.path.splitext(f)[1] in (".ckpt", ".safetensors")])
 all_samplers = set(default_samplers.samplers.keys()) | set(k_samplers.samplers.keys())
@@ -198,8 +199,8 @@ def run_test():
 
 
 def run_samplers(context, model_filename, out_dir_path, width, height, vram_usage_level):
-    from threading import Thread, Event
     from queue import Queue
+    from threading import Event, Thread
 
     for sampler_name in samplers_to_test:
         # setup
@@ -302,9 +303,10 @@ def get_min_size(model_path, default_size=512):
 
 
 def log_perf_results():
-    import pandas as pd
-    import numpy as np
     from importlib.metadata import version
+
+    import numpy as np
+    import pandas as pd
 
     pd.set_option("display.max_rows", 1000)
 

--- a/scripts/run_everything.py
+++ b/scripts/run_everything.py
@@ -1,7 +1,7 @@
-'''
+"""
 Runs the desired Stable Diffusion models against the desired samplers. Saves the output images
 to disk, along with the peak RAM and VRAM usage, as well as the sampling performance.
-'''
+"""
 import os
 import time
 import argparse
@@ -9,59 +9,101 @@ from sdkit.utils import log, get_device_usage
 
 # args
 parser = argparse.ArgumentParser()
-parser.add_argument('--prompt', type=str, default="Photograph of an astronaut riding a horse", help="Prompt to use for generating the image")
-parser.add_argument('--seed', type=int, default=42, help="Seed to use for generating the image")
-parser.add_argument('--models-dir', type=str, required=True, help="Path to the directory containing the Stable Diffusion models")
-parser.add_argument('--out-dir', type=str, required=True, help="Path to the directory to save the generated images and test results")
-parser.add_argument('--models', default='all', help="Comma-separated list of model filenames (without spaces) to test. Default: all")
-parser.add_argument('--exclude-models', default=set(), help="Comma-separated list of model filenames (without spaces) to skip. Supports wildcards (without commas), for e.g. --exclude-models *.safetensors, or --exclude-models sd-1-4*")
-parser.add_argument('--samplers', default='all', help="Comma-separated list of sampler names (without spaces) to test. Default: all")
-parser.add_argument('--exclude-samplers', default=set(), help="Comma-separated list of sampler names (without spaces) to skip")
-parser.add_argument('--init-image', default=None, help="Path to an initial image to use. Only works with DDIM sampler (for now).")
-parser.add_argument('--vram-usage-levels', default='balanced', help="Comma-separated list of VRAM usage levels. Allowed values: low, balanced, high")
-parser.add_argument('--skip-completed', default=False, help="Skips a model or sampler if it has already been tested (i.e. an output image exists for it)")
-parser.add_argument('--steps', default=25, type=int, help="Number of inference steps to run for each sampler")
-parser.add_argument('--sizes', default='auto', type=str, help="Comma-separated list of image sizes (width x height). No spaces. E.g. 512x512 or 512x512,1024x768. Defaults to what the model needs (512x512 or 768x768, if the model requires 768)")
-parser.add_argument('--device', default='cuda:0', type=str, help="Specify the device to run on. E.g. cpu or cuda:0 or cuda:1 etc")
-parser.add_argument('--live-perf', action="store_true", help="Print the RAM and VRAM usage stats every few seconds")
+parser.add_argument(
+    "--prompt",
+    type=str,
+    default="Photograph of an astronaut riding a horse",
+    help="Prompt to use for generating the image",
+)
+parser.add_argument("--seed", type=int, default=42, help="Seed to use for generating the image")
+parser.add_argument(
+    "--models-dir", type=str, required=True, help="Path to the directory containing the Stable Diffusion models"
+)
+parser.add_argument(
+    "--out-dir", type=str, required=True, help="Path to the directory to save the generated images and test results"
+)
+parser.add_argument(
+    "--models", default="all", help="Comma-separated list of model filenames (without spaces) to test. Default: all"
+)
+parser.add_argument(
+    "--exclude-models",
+    default=set(),
+    help="Comma-separated list of model filenames (without spaces) to skip. Supports wildcards (without commas), for e.g. --exclude-models *.safetensors, or --exclude-models sd-1-4*",
+)
+parser.add_argument(
+    "--samplers", default="all", help="Comma-separated list of sampler names (without spaces) to test. Default: all"
+)
+parser.add_argument(
+    "--exclude-samplers", default=set(), help="Comma-separated list of sampler names (without spaces) to skip"
+)
+parser.add_argument(
+    "--init-image", default=None, help="Path to an initial image to use. Only works with DDIM sampler (for now)."
+)
+parser.add_argument(
+    "--vram-usage-levels",
+    default="balanced",
+    help="Comma-separated list of VRAM usage levels. Allowed values: low, balanced, high",
+)
+parser.add_argument(
+    "--skip-completed",
+    default=False,
+    help="Skips a model or sampler if it has already been tested (i.e. an output image exists for it)",
+)
+parser.add_argument("--steps", default=25, type=int, help="Number of inference steps to run for each sampler")
+parser.add_argument(
+    "--sizes",
+    default="auto",
+    type=str,
+    help="Comma-separated list of image sizes (width x height). No spaces. E.g. 512x512 or 512x512,1024x768. Defaults to what the model needs (512x512 or 768x768, if the model requires 768)",
+)
+parser.add_argument(
+    "--device", default="cuda:0", type=str, help="Specify the device to run on. E.g. cpu or cuda:0 or cuda:1 etc"
+)
+parser.add_argument("--live-perf", action="store_true", help="Print the RAM and VRAM usage stats every few seconds")
 parser.set_defaults(live_perf=False)
 args = parser.parse_args()
 
-if args.models != 'all': args.models = set(args.models.split(','))
-if args.exclude_models != set() and '*' not in args.exclude_models: args.exclude_models = set(args.exclude_models.split(','))
-if args.samplers != 'all': args.samplers = set(args.samplers.split(','))
-if args.exclude_samplers != set(): args.exclude_samplers = set(args.exclude_samplers.split(','))
-if args.sizes != 'auto': args.sizes = [tuple(map(lambda x: int(x), size.split('x'))) for size in args.sizes.split(',')]
+if args.models != "all":
+    args.models = set(args.models.split(","))
+if args.exclude_models != set() and "*" not in args.exclude_models:
+    args.exclude_models = set(args.exclude_models.split(","))
+if args.samplers != "all":
+    args.samplers = set(args.samplers.split(","))
+if args.exclude_samplers != set():
+    args.exclude_samplers = set(args.exclude_samplers.split(","))
+if args.sizes != "auto":
+    args.sizes = [tuple(map(lambda x: int(x), size.split("x"))) for size in args.sizes.split(",")]
 
 # setup
-log.info('Starting..')
+log.info("Starting..")
 from sdkit.models import load_model
 from sdkit.generate.sampler import default_samplers, k_samplers
 
-sd_models = set([f for f in os.listdir(args.models_dir) if os.path.splitext(f)[1] in ('.ckpt', '.safetensors')])
+sd_models = set([f for f in os.listdir(args.models_dir) if os.path.splitext(f)[1] in (".ckpt", ".safetensors")])
 all_samplers = set(default_samplers.samplers.keys()) | set(k_samplers.samplers.keys())
-args.vram_usage_levels = args.vram_usage_levels.split(',')
+args.vram_usage_levels = args.vram_usage_levels.split(",")
 
-if isinstance(args.exclude_models, str) and '*' in args.exclude_models:
+if isinstance(args.exclude_models, str) and "*" in args.exclude_models:
     import fnmatch
+
     args.exclude_models = set(fnmatch.filter(sd_models, args.exclude_models))
 
-models_to_test = sd_models if args.models == 'all' else args.models
+models_to_test = sd_models if args.models == "all" else args.models
 models_to_test -= args.exclude_models
-samplers_to_test = all_samplers if args.samplers == 'all' else args.samplers
+samplers_to_test = all_samplers if args.samplers == "all" else args.samplers
 samplers_to_test -= args.exclude_samplers
 vram_usage_levels_to_test = args.vram_usage_levels
 
 if args.init_image is not None:
     if not os.path.exists(args.init_image):
-        log.error(f'Error! Could not an initial image at the path specified: {args.init_image}')
+        log.error(f"Error! Could not an initial image at the path specified: {args.init_image}")
         exit(1)
 
-    if samplers_to_test != {'ddim'}:
+    if samplers_to_test != {"ddim"}:
         log.error('We only support the "ddim" sampler for img2img right now!')
         exit(1)
 
-    all_samplers = {'ddim'}
+    all_samplers = {"ddim"}
 
 # setup the test
 from sdkit import Context
@@ -69,19 +111,34 @@ from sdkit.generate import generate_images
 from sdkit.models import get_model_info_from_db
 from sdkit.utils import hash_file_quick
 
-perf_results = [['model_filename', 'vram_usage_level', 'sampler_name', 'max_ram (GB)', 'max_vram (GB)', 'image_size', 'time_taken (s)', 'speed (it/s)', 'render_test', 'ram_usage', 'vram_usage']]
-perf_results_file = f'perf_results_{time.time()}.csv'
+perf_results = [
+    [
+        "model_filename",
+        "vram_usage_level",
+        "sampler_name",
+        "max_ram (GB)",
+        "max_vram (GB)",
+        "image_size",
+        "time_taken (s)",
+        "speed (it/s)",
+        "render_test",
+        "ram_usage",
+        "vram_usage",
+    ]
+]
+perf_results_file = f"perf_results_{time.time()}.csv"
 
 # print test info
-log.info('---')
-log.info(f'Models actually being tested: {models_to_test}')
-log.info(f'Samplers actually being tested: {samplers_to_test}')
-log.info(f'VRAM usage levels being tested: {vram_usage_levels_to_test}')
-log.info(f'Image sizes being tested: {args.sizes}')
-log.info('---')
-log.info(f'Available models: {sd_models}')
-log.info(f'Available samplers: {all_samplers}')
-log.info('---')
+log.info("---")
+log.info(f"Models actually being tested: {models_to_test}")
+log.info(f"Samplers actually being tested: {samplers_to_test}")
+log.info(f"VRAM usage levels being tested: {vram_usage_levels_to_test}")
+log.info(f"Image sizes being tested: {args.sizes}")
+log.info("---")
+log.info(f"Available models: {sd_models}")
+log.info(f"Available samplers: {all_samplers}")
+log.info("---")
+
 
 # run the test
 def run_test():
@@ -89,7 +146,7 @@ def run_test():
         model_dir_path = os.path.join(args.out_dir, model_filename)
 
         if args.skip_completed and is_model_already_tested(model_dir_path):
-            log.info(f'skipping model {model_filename} since it has already been processed at {model_dir_path}')
+            log.info(f"skipping model {model_filename} since it has already been processed at {model_dir_path}")
             continue
 
         for vram_usage_level in vram_usage_levels_to_test:
@@ -102,24 +159,33 @@ def run_test():
             os.makedirs(out_dir_path, exist_ok=True)
 
             try:
-                context.model_paths['stable-diffusion'] = os.path.join(args.models_dir, model_filename)
-                load_model(context, 'stable-diffusion', scan_model=False)
+                context.model_paths["stable-diffusion"] = os.path.join(args.models_dir, model_filename)
+                load_model(context, "stable-diffusion", scan_model=False)
             except Exception as e:
                 log.exception(e)
-                perf_results.append([model_filename, vram_usage_level, 'n/a', 'n/a', 'n/a', 'n/a', 'n/a', 'n/a', False, [], []])
+                perf_results.append(
+                    [model_filename, vram_usage_level, "n/a", "n/a", "n/a", "n/a", "n/a", "n/a", False, [], []]
+                )
                 log_perf_results()
                 continue
 
-
             # run a warm-up, before running the actual samplers
-            log.info('Warming up..')
+            log.info("Warming up..")
             try:
-                generate_images(context, prompt='Photograph of an astronaut riding a horse', num_inference_steps=10, seed=42, width=512, height=512, sampler_name='euler_a')
+                generate_images(
+                    context,
+                    prompt="Photograph of an astronaut riding a horse",
+                    num_inference_steps=10,
+                    seed=42,
+                    width=512,
+                    height=512,
+                    sampler_name="euler_a",
+                )
             except:
                 pass
 
-            if args.sizes == 'auto':
-                min_size = get_min_size(context.model_paths['stable-diffusion'])
+            if args.sizes == "auto":
+                min_size = get_min_size(context.model_paths["stable-diffusion"])
                 sizes = [(min_size, min_size)]
             else:
                 sizes = args.sizes
@@ -130,29 +196,35 @@ def run_test():
 
             del context
 
+
 def run_samplers(context, model_filename, out_dir_path, width, height, vram_usage_level):
     from threading import Thread, Event
     from queue import Queue
 
     for sampler_name in samplers_to_test:
         # setup
-        img_path = os.path.join(out_dir_path, f'{sampler_name}_0.jpeg')
+        img_path = os.path.join(out_dir_path, f"{sampler_name}_0.jpeg")
         if args.skip_completed and os.path.exists(img_path):
-            log.info(f'skipping sampler {sampler_name} since it has already been processed at {img_path}')
+            log.info(f"skipping sampler {sampler_name} since it has already been processed at {img_path}")
             continue
 
-        log.info(f'Model: {model_filename}, Sampler: {sampler_name}, Size: {width}x{height}, VRAM Usage Level: {vram_usage_level}')
+        log.info(
+            f"Model: {model_filename}, Sampler: {sampler_name}, Size: {width}x{height}, VRAM Usage Level: {vram_usage_level}"
+        )
 
         # start profiling
         prof_thread_stop_event = Event()
         ram_usage = Queue()
         vram_usage = Queue()
-        prof_thread = Thread(target=profiling_thread, kwargs={
-            'device': context.device,
-            'prof_thread_stop_event': prof_thread_stop_event,
-            'ram_usage': ram_usage,
-            'vram_usage': vram_usage,
-        })
+        prof_thread = Thread(
+            target=profiling_thread,
+            kwargs={
+                "device": context.device,
+                "prof_thread_stop_event": prof_thread_stop_event,
+                "ram_usage": ram_usage,
+                "vram_usage": vram_usage,
+            },
+        )
         prof_thread.start()
 
         t, speed = time.time(), 0
@@ -164,7 +236,8 @@ def run_samplers(context, model_filename, out_dir_path, width, height, vram_usag
                 prompt=args.prompt,
                 seed=args.seed,
                 num_inference_steps=args.steps,
-                width=width, height=height,
+                width=width,
+                height=height,
                 sampler_name=sampler_name,
                 init_image=args.init_image,
             )
@@ -182,9 +255,24 @@ def run_samplers(context, model_filename, out_dir_path, width, height, vram_usag
             prof_thread_stop_event.set()
             prof_thread.join()
 
-        perf_results.append([model_filename, vram_usage_level, sampler_name, f'{max(ram_usage.queue):.1f}', f'{max(vram_usage.queue):.1f}', f'{width}x{height}', f'{t:.1f}', f'{speed:.1f}', render_success, list(ram_usage.queue), list(vram_usage.queue)])
+        perf_results.append(
+            [
+                model_filename,
+                vram_usage_level,
+                sampler_name,
+                f"{max(ram_usage.queue):.1f}",
+                f"{max(vram_usage.queue):.1f}",
+                f"{width}x{height}",
+                f"{t:.1f}",
+                f"{speed:.1f}",
+                render_success,
+                list(ram_usage.queue),
+                list(vram_usage.queue),
+            ]
+        )
 
         log_perf_results()
+
 
 def profiling_thread(device, prof_thread_stop_event, ram_usage, vram_usage):
     import time
@@ -197,60 +285,64 @@ def profiling_thread(device, prof_thread_stop_event, ram_usage, vram_usage):
 
         time.sleep(1)
 
+
 def is_model_already_tested(out_dir_path):
     if not os.path.exists(out_dir_path):
         return False
 
-    sampler_files = list(map(lambda x: os.path.join(out_dir_path, f'{x}_0.jpeg'), samplers_to_test))
+    sampler_files = list(map(lambda x: os.path.join(out_dir_path, f"{x}_0.jpeg"), samplers_to_test))
     images_exist = list(map(lambda x: os.path.exists(x), sampler_files))
     return all(images_exist)
+
 
 def get_min_size(model_path, default_size=512):
     model_info = get_model_info_from_db(quick_hash=hash_file_quick(model_path))
 
-    return model_info['metadata']['min_size'] if model_info is not None else default_size
+    return model_info["metadata"]["min_size"] if model_info is not None else default_size
+
 
 def log_perf_results():
     import pandas as pd
     import numpy as np
     from importlib.metadata import version
 
-    pd.set_option('display.max_rows', 1000)
+    pd.set_option("display.max_rows", 1000)
 
-    print('\n-- Performance summary --')
+    print("\n-- Performance summary --")
     print(f"sdkit version: {version('sdkit')}")
     print(f"stable-diffusion-sdkit version: {version('stable-diffusion-sdkit')}")
-    print(f'Device: {args.device}')
-    print(f'Num inference steps: {args.steps}')
-    print('')
+    print(f"Device: {args.device}")
+    print(f"Num inference steps: {args.steps}")
+    print("")
 
     df = pd.DataFrame(data=perf_results)
     df = df.rename(columns=df.iloc[0]).drop(df.index[0])
-    df = df.sort_values(by=['image_size', 'model_filename'], ascending=False)
+    df = df.sort_values(by=["image_size", "model_filename"], ascending=False)
     df = df.reset_index(drop=True)
 
-    df['vram_tp90'] = df['vram_usage'].apply(lambda x: np.percentile(x, 90))
-    df['vram_tp100'] = df['vram_usage'].apply(lambda x: np.percentile(x, 100))
-    df['vram_spike_test'] = abs((df['vram_tp100'] - df['vram_tp90'])) < 0.5 # okay with a spike of 500 MB
-    df['vram_tp90'] = df['vram_tp90'].apply(lambda x: f'{x:.1f}')
-    df['overall_status'] = df['render_test'] & df['vram_spike_test']
+    df["vram_tp90"] = df["vram_usage"].apply(lambda x: np.percentile(x, 90))
+    df["vram_tp100"] = df["vram_usage"].apply(lambda x: np.percentile(x, 100))
+    df["vram_spike_test"] = abs((df["vram_tp100"] - df["vram_tp90"])) < 0.5  # okay with a spike of 500 MB
+    df["vram_tp90"] = df["vram_tp90"].apply(lambda x: f"{x:.1f}")
+    df["overall_status"] = df["render_test"] & df["vram_spike_test"]
 
-    df['vram_spike_test'] = df['vram_spike_test'].apply(lambda is_pass: 'pass' if is_pass else 'FAIL')
-    df['render_test'] = df['render_test'].apply(lambda is_pass: 'pass' if is_pass else 'FAIL')
-    df['overall_status'] = df['overall_status'].apply(lambda is_pass: 'pass' if is_pass else 'FAIL')
+    df["vram_spike_test"] = df["vram_spike_test"].apply(lambda is_pass: "pass" if is_pass else "FAIL")
+    df["render_test"] = df["render_test"].apply(lambda is_pass: "pass" if is_pass else "FAIL")
+    df["overall_status"] = df["overall_status"].apply(lambda is_pass: "pass" if is_pass else "FAIL")
 
-    del df['vram_tp100']
+    del df["vram_tp100"]
 
     out_file = os.path.join(args.out_dir, perf_results_file)
     df.to_csv(out_file, index=False)
 
     # print the summary
-    del df['vram_usage']
-    del df['ram_usage']
+    del df["vram_usage"]
+    del df["ram_usage"]
 
     print(df)
-    print('')
+    print("")
 
-    print(f'Written the performance summary to {out_file}\n')
+    print(f"Written the performance summary to {out_file}\n")
+
 
 run_test()

--- a/scripts/txt2img_original.py
+++ b/scripts/txt2img_original.py
@@ -1,8 +1,8 @@
-'''
+"""
 A simplified version of the original txt2img.py script that is included with Stable Diffusion 2.0.
 
 Useful for testing responses and memory usage against the original script.
-'''
+"""
 
 import torch
 import numpy as np
@@ -22,9 +22,11 @@ from ldm.models.diffusion.dpm_solver import DPMSolverSampler
 
 torch.set_grad_enabled(False)
 
+
 def chunk(it, size):
     it = iter(it)
     return iter(lambda: tuple(islice(it, size)), ())
+
 
 def load_model_from_config(config, ckpt, verbose=False):
     print(f"Loading model from {ckpt}")
@@ -44,6 +46,7 @@ def load_model_from_config(config, ckpt, verbose=False):
     model.cuda()
     model.eval()
     return model
+
 
 def main():
     seed_everything(42)
@@ -67,37 +70,38 @@ def main():
 
     for i in range(4):
         precision_scope = autocast
-        with torch.no_grad(), \
-            precision_scope("cuda"), \
-            model.ema_scope():
-                for n in trange(1, desc="Sampling"):
-                    for prompts in tqdm(data, desc="data"):
-                        uc = None
-                        uc = model.get_learned_conditioning(batch_size * [""])
-                        if isinstance(prompts, tuple):
-                            prompts = list(prompts)
-                        c = model.get_learned_conditioning(prompts)
-                        shape = [4, 2048 // 8, 2048 // 8]
-                        try:
-                            samples, _ = sampler.sample(S=1,
-                                                            conditioning=c,
-                                                            batch_size=1,
-                                                            shape=shape,
-                                                            verbose=False,
-                                                            unconditional_guidance_scale=7.5,
-                                                            unconditional_conditioning=uc,
-                                                            eta=0.,
-                                                            x_T=start_code)
+        with torch.no_grad(), precision_scope("cuda"), model.ema_scope():
+            for n in trange(1, desc="Sampling"):
+                for prompts in tqdm(data, desc="data"):
+                    uc = None
+                    uc = model.get_learned_conditioning(batch_size * [""])
+                    if isinstance(prompts, tuple):
+                        prompts = list(prompts)
+                    c = model.get_learned_conditioning(prompts)
+                    shape = [4, 2048 // 8, 2048 // 8]
+                    try:
+                        samples, _ = sampler.sample(
+                            S=1,
+                            conditioning=c,
+                            batch_size=1,
+                            shape=shape,
+                            verbose=False,
+                            unconditional_guidance_scale=7.5,
+                            unconditional_conditioning=uc,
+                            eta=0.0,
+                            x_T=start_code,
+                        )
 
-                            x_samples = model.decode_first_stage(samples)
-                            x_samples = torch.clamp((x_samples + 1.0) / 2.0, min=0.0, max=1.0)
+                        x_samples = model.decode_first_stage(samples)
+                        x_samples = torch.clamp((x_samples + 1.0) / 2.0, min=0.0, max=1.0)
 
-                            for x_sample in x_samples:
-                                x_sample = 255. * rearrange(x_sample.cpu().numpy(), 'c h w -> h w c')
-                                img = Image.fromarray(x_sample.astype(np.uint8))
-                                base_count += 1
-                                sample_count += 1
-                        except Exception as e:
-                            print(e)
+                        for x_sample in x_samples:
+                            x_sample = 255.0 * rearrange(x_sample.cpu().numpy(), "c h w -> h w c")
+                            img = Image.fromarray(x_sample.astype(np.uint8))
+                            base_count += 1
+                            sample_count += 1
+                    except Exception as e:
+                        print(e)
+
 
 main()

--- a/scripts/txt2img_original.py
+++ b/scripts/txt2img_original.py
@@ -49,7 +49,7 @@ def main():
     seed_everything(42)
 
     config = OmegaConf.load("path/to/models/stable-diffusion/v1-inference.yaml")
-    model = load_model_from_config(config, f"path/to/models/stable-diffusion/sd-v1-4.ckpt")
+    model = load_model_from_config(config, "path/to/models/stable-diffusion/sd-v1-4.ckpt")
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
     model = model.to(device)

--- a/scripts/txt2img_original.py
+++ b/scripts/txt2img_original.py
@@ -4,21 +4,21 @@ A simplified version of the original txt2img.py script that is included with Sta
 Useful for testing responses and memory usage against the original script.
 """
 
-import torch
+from contextlib import nullcontext
+from itertools import islice
+
 import numpy as np
+import torch
+from einops import rearrange
+from ldm.models.diffusion.ddim import DDIMSampler
+from ldm.models.diffusion.dpm_solver import DPMSolverSampler
+from ldm.models.diffusion.plms import PLMSSampler
+from ldm.util import instantiate_from_config
 from omegaconf import OmegaConf
 from PIL import Image
-from tqdm import tqdm, trange
-from itertools import islice
-from einops import rearrange
 from pytorch_lightning import seed_everything
 from torch import autocast
-from contextlib import nullcontext
-
-from ldm.util import instantiate_from_config
-from ldm.models.diffusion.ddim import DDIMSampler
-from ldm.models.diffusion.plms import PLMSSampler
-from ldm.models.diffusion.dpm_solver import DPMSolverSampler
+from tqdm import tqdm, trange
 
 torch.set_grad_enabled(False)
 

--- a/scripts/txt2img_original.py
+++ b/scripts/txt2img_original.py
@@ -1,8 +1,8 @@
-'''
+"""
 A simplified version of the original txt2img.py script that is included with Stable Diffusion 2.0.
 
 Useful for testing responses and memory usage against the original script.
-'''
+"""
 
 import torch
 import numpy as np
@@ -22,9 +22,11 @@ from ldm.models.diffusion.dpm_solver import DPMSolverSampler
 
 torch.set_grad_enabled(False)
 
+
 def chunk(it, size):
     it = iter(it)
     return iter(lambda: tuple(islice(it, size)), ())
+
 
 def load_model_from_config(config, ckpt, verbose=False):
     print(f"Loading model from {ckpt}")
@@ -45,11 +47,14 @@ def load_model_from_config(config, ckpt, verbose=False):
     model.eval()
     return model
 
+
 def main():
     seed_everything(42)
 
     config = OmegaConf.load("path/to/models/stable-diffusion/v1-inference.yaml")
-    model = load_model_from_config(config, f"path/to/models/stable-diffusion/sd-v1-4.ckpt")
+    model = load_model_from_config(
+        config, f"path/to/models/stable-diffusion/sd-v1-4.ckpt"
+    )
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
     model = model.to(device)
@@ -67,37 +72,42 @@ def main():
 
     for i in range(4):
         precision_scope = autocast
-        with torch.no_grad(), \
-            precision_scope("cuda"), \
-            model.ema_scope():
-                for n in trange(1, desc="Sampling"):
-                    for prompts in tqdm(data, desc="data"):
-                        uc = None
-                        uc = model.get_learned_conditioning(batch_size * [""])
-                        if isinstance(prompts, tuple):
-                            prompts = list(prompts)
-                        c = model.get_learned_conditioning(prompts)
-                        shape = [4, 2048 // 8, 2048 // 8]
-                        try:
-                            samples, _ = sampler.sample(S=1,
-                                                            conditioning=c,
-                                                            batch_size=1,
-                                                            shape=shape,
-                                                            verbose=False,
-                                                            unconditional_guidance_scale=7.5,
-                                                            unconditional_conditioning=uc,
-                                                            eta=0.,
-                                                            x_T=start_code)
+        with torch.no_grad(), precision_scope("cuda"), model.ema_scope():
+            for n in trange(1, desc="Sampling"):
+                for prompts in tqdm(data, desc="data"):
+                    uc = None
+                    uc = model.get_learned_conditioning(batch_size * [""])
+                    if isinstance(prompts, tuple):
+                        prompts = list(prompts)
+                    c = model.get_learned_conditioning(prompts)
+                    shape = [4, 2048 // 8, 2048 // 8]
+                    try:
+                        samples, _ = sampler.sample(
+                            S=1,
+                            conditioning=c,
+                            batch_size=1,
+                            shape=shape,
+                            verbose=False,
+                            unconditional_guidance_scale=7.5,
+                            unconditional_conditioning=uc,
+                            eta=0.0,
+                            x_T=start_code,
+                        )
 
-                            x_samples = model.decode_first_stage(samples)
-                            x_samples = torch.clamp((x_samples + 1.0) / 2.0, min=0.0, max=1.0)
+                        x_samples = model.decode_first_stage(samples)
+                        x_samples = torch.clamp(
+                            (x_samples + 1.0) / 2.0, min=0.0, max=1.0
+                        )
 
-                            for x_sample in x_samples:
-                                x_sample = 255. * rearrange(x_sample.cpu().numpy(), 'c h w -> h w c')
-                                img = Image.fromarray(x_sample.astype(np.uint8))
-                                base_count += 1
-                                sample_count += 1
-                        except Exception as e:
-                            print(e)
+                        for x_sample in x_samples:
+                            x_sample = 255.0 * rearrange(
+                                x_sample.cpu().numpy(), "c h w -> h w c"
+                            )
+                            img = Image.fromarray(x_sample.astype(np.uint8))
+                            base_count += 1
+                            sample_count += 1
+                    except Exception as e:
+                        print(e)
+
 
 main()

--- a/scripts/txt2img_original.py
+++ b/scripts/txt2img_original.py
@@ -1,27 +1,30 @@
-"""
+'''
 A simplified version of the original txt2img.py script that is included with Stable Diffusion 2.0.
 
 Useful for testing responses and memory usage against the original script.
-"""
-
-from itertools import islice
+'''
 
 import torch
-from einops import rearrange
-from ldm.models.diffusion.plms import PLMSSampler
-from ldm.util import instantiate_from_config
+import numpy as np
 from omegaconf import OmegaConf
+from PIL import Image
+from tqdm import tqdm, trange
+from itertools import islice
+from einops import rearrange
 from pytorch_lightning import seed_everything
 from torch import autocast
-from tqdm import tqdm, trange
+from contextlib import nullcontext
+
+from ldm.util import instantiate_from_config
+from ldm.models.diffusion.ddim import DDIMSampler
+from ldm.models.diffusion.plms import PLMSSampler
+from ldm.models.diffusion.dpm_solver import DPMSolverSampler
 
 torch.set_grad_enabled(False)
-
 
 def chunk(it, size):
     it = iter(it)
     return iter(lambda: tuple(islice(it, size)), ())
-
 
 def load_model_from_config(config, ckpt, verbose=False):
     print(f"Loading model from {ckpt}")
@@ -42,12 +45,11 @@ def load_model_from_config(config, ckpt, verbose=False):
     model.eval()
     return model
 
-
 def main():
     seed_everything(42)
 
     config = OmegaConf.load("path/to/models/stable-diffusion/v1-inference.yaml")
-    model = load_model_from_config(config, "path/to/models/stable-diffusion/sd-v1-4.ckpt")
+    model = load_model_from_config(config, f"path/to/models/stable-diffusion/sd-v1-4.ckpt")
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
     model = model.to(device)
@@ -59,44 +61,43 @@ def main():
     assert prompt is not None
     data = [batch_size * [prompt]]
 
-    # sample_count = 0
+    sample_count = 0
 
     start_code = None
 
     for i in range(4):
         precision_scope = autocast
-        with torch.no_grad(), precision_scope("cuda"), model.ema_scope():
-            for n in trange(1, desc="Sampling"):
-                for prompts in tqdm(data, desc="data"):
-                    uc = None
-                    uc = model.get_learned_conditioning(batch_size * [""])
-                    if isinstance(prompts, tuple):
-                        prompts = list(prompts)
-                    c = model.get_learned_conditioning(prompts)
-                    shape = [4, 2048 // 8, 2048 // 8]
-                    try:
-                        samples, _ = sampler.sample(
-                            S=1,
-                            conditioning=c,
-                            batch_size=1,
-                            shape=shape,
-                            verbose=False,
-                            unconditional_guidance_scale=7.5,
-                            unconditional_conditioning=uc,
-                            eta=0.0,
-                            x_T=start_code,
-                        )
+        with torch.no_grad(), \
+            precision_scope("cuda"), \
+            model.ema_scope():
+                for n in trange(1, desc="Sampling"):
+                    for prompts in tqdm(data, desc="data"):
+                        uc = None
+                        uc = model.get_learned_conditioning(batch_size * [""])
+                        if isinstance(prompts, tuple):
+                            prompts = list(prompts)
+                        c = model.get_learned_conditioning(prompts)
+                        shape = [4, 2048 // 8, 2048 // 8]
+                        try:
+                            samples, _ = sampler.sample(S=1,
+                                                            conditioning=c,
+                                                            batch_size=1,
+                                                            shape=shape,
+                                                            verbose=False,
+                                                            unconditional_guidance_scale=7.5,
+                                                            unconditional_conditioning=uc,
+                                                            eta=0.,
+                                                            x_T=start_code)
 
-                        x_samples = model.decode_first_stage(samples)
-                        x_samples = torch.clamp((x_samples + 1.0) / 2.0, min=0.0, max=1.0)
+                            x_samples = model.decode_first_stage(samples)
+                            x_samples = torch.clamp((x_samples + 1.0) / 2.0, min=0.0, max=1.0)
 
-                        for x_sample in x_samples:
-                            x_sample = 255.0 * rearrange(x_sample.cpu().numpy(), "c h w -> h w c")
-                            # img = Image.fromarray(x_sample.astype(np.uint8))
-                            # base_count += 1
-                            # sample_count += 1
-                    except Exception as e:
-                        print(e)
-
+                            for x_sample in x_samples:
+                                x_sample = 255. * rearrange(x_sample.cpu().numpy(), 'c h w -> h w c')
+                                img = Image.fromarray(x_sample.astype(np.uint8))
+                                base_count += 1
+                                sample_count += 1
+                        except Exception as e:
+                            print(e)
 
 main()

--- a/scripts/txt2img_original.py
+++ b/scripts/txt2img_original.py
@@ -4,18 +4,13 @@ A simplified version of the original txt2img.py script that is included with Sta
 Useful for testing responses and memory usage against the original script.
 """
 
-from contextlib import nullcontext
 from itertools import islice
 
-import numpy as np
 import torch
 from einops import rearrange
-from ldm.models.diffusion.ddim import DDIMSampler
-from ldm.models.diffusion.dpm_solver import DPMSolverSampler
 from ldm.models.diffusion.plms import PLMSSampler
 from ldm.util import instantiate_from_config
 from omegaconf import OmegaConf
-from PIL import Image
 from pytorch_lightning import seed_everything
 from torch import autocast
 from tqdm import tqdm, trange
@@ -52,9 +47,7 @@ def main():
     seed_everything(42)
 
     config = OmegaConf.load("path/to/models/stable-diffusion/v1-inference.yaml")
-    model = load_model_from_config(
-        config, f"path/to/models/stable-diffusion/sd-v1-4.ckpt"
-    )
+    model = load_model_from_config(config, "path/to/models/stable-diffusion/sd-v1-4.ckpt")
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
     model = model.to(device)
@@ -66,7 +59,7 @@ def main():
     assert prompt is not None
     data = [batch_size * [prompt]]
 
-    sample_count = 0
+    # sample_count = 0
 
     start_code = None
 
@@ -95,17 +88,13 @@ def main():
                         )
 
                         x_samples = model.decode_first_stage(samples)
-                        x_samples = torch.clamp(
-                            (x_samples + 1.0) / 2.0, min=0.0, max=1.0
-                        )
+                        x_samples = torch.clamp((x_samples + 1.0) / 2.0, min=0.0, max=1.0)
 
                         for x_sample in x_samples:
-                            x_sample = 255.0 * rearrange(
-                                x_sample.cpu().numpy(), "c h w -> h w c"
-                            )
-                            img = Image.fromarray(x_sample.astype(np.uint8))
-                            base_count += 1
-                            sample_count += 1
+                            x_sample = 255.0 * rearrange(x_sample.cpu().numpy(), "c h w -> h w c")
+                            # img = Image.fromarray(x_sample.astype(np.uint8))
+                            # base_count += 1
+                            # sample_count += 1
                     except Exception as e:
                         print(e)
 

--- a/scripts/txt2img_original.py
+++ b/scripts/txt2img_original.py
@@ -4,14 +4,11 @@ A simplified version of the original txt2img.py script that is included with Sta
 Useful for testing responses and memory usage against the original script.
 """
 
-from contextlib import nullcontext
 from itertools import islice
 
 import numpy as np
 import torch
 from einops import rearrange
-from ldm.models.diffusion.ddim import DDIMSampler
-from ldm.models.diffusion.dpm_solver import DPMSolverSampler
 from ldm.models.diffusion.plms import PLMSSampler
 from ldm.util import instantiate_from_config
 from omegaconf import OmegaConf
@@ -97,8 +94,7 @@ def main():
 
                         for x_sample in x_samples:
                             x_sample = 255.0 * rearrange(x_sample.cpu().numpy(), "c h w -> h w c")
-                            img = Image.fromarray(x_sample.astype(np.uint8))
-                            base_count += 1
+                            Image.fromarray(x_sample.astype(np.uint8))
                             sample_count += 1
                     except Exception as e:
                         print(e)

--- a/sdkit/__init__.py
+++ b/sdkit/__init__.py
@@ -14,23 +14,27 @@ class Context(local):
         self.device_name: str = None
         self.vram_optimizations: set = set()
         """
-        **Do not change this unless you know what you're doing!** Instead set `context.vram_usage_level` to `'low'`, `'balanced'` or `'high'`.
+        **Do not change this unless you know what you're doing!**
+        Instead set `context.vram_usage_level` to `'low'`, `'balanced'` or `'high'`.
 
         Possible values:
         * Empty set: Fastest, and consumes the maximum amount of VRAM.
 
-        * `'KEEP_FS_AND_CS_IN_CPU'`: Honestly, not very useful. Slightly slower than `None`, but consumes slightly less VRAM than `None`.
-        For the sd-v1-4 model, it consumes atleast 8% less VRAM than `None`. It moves the first_stage and cond_stage
-        to the CPU, and keeps the rest of the model in GPU (input, middle and output blocks). The first_stage
-        and cond_stage will be moved to the GPU only when they are needed, and moved back to the CPU after that.
+        * `'KEEP_FS_AND_CS_IN_CPU'`: Honestly, not very useful.
+            Slightly slower than `None`, but consumes slightly less VRAM than `None`.
+            For the sd-v1-4 model, it consumes atleast 8% less VRAM than `None`. It moves the first_stage and cond_stage
+            to the CPU, and keeps the rest of the model in GPU (input, middle and output blocks). The first_stage
+            and cond_stage will be moved to the GPU only when they are needed, and moved back to the CPU after that.
 
-        * `'KEEP_ENTIRE_MODEL_IN_CPU'`: Very useful! Slowest option, consumes the least amount of VRAM. For the sd-v1-4 model,
-        it consumes atleast 52% less VRAM than using no optimizations. Along with the first_stage and cond_stage, it also moves the input,
-        middle and output blocks to the CPU (effectively, the entire model is kept in CPU). Each block will be moved
-        to the GPU only when they are needed, and moved back to the CPU after that.
+        * `'KEEP_ENTIRE_MODEL_IN_CPU'`: Very useful! Slowest option, consumes the least amount of VRAM.
+            For the sd-v1-4 model,
+            it consumes atleast 52% less VRAM than using no optimizations. Along with the first_stage and cond_stage,
+            it also moves the input, middle and output blocks to the CPU (effectively, the entire model is kept in CPU).
+            Each block will be moved to the GPU only when they are needed, and moved back to the CPU after that.
 
-        * `'SET_ATTENTION_STEP_TO_4'`: Pretty useful! Fairly fast performance, consumes a medium amount of VRAM. For the sd-v1-4 model,
-        it consumes about 1 GB more than `'KEEP_ENTIRE_MODEL_IN_CPU'`, for a much faster rendering performance.
+        * `'SET_ATTENTION_STEP_TO_4'`: Pretty useful! Fairly fast performance, consumes a medium amount of VRAM.
+            For the sd-v1-4 model,
+            it consumes about 1 GB more than `'KEEP_ENTIRE_MODEL_IN_CPU'`, for a much faster rendering performance.
 
         * `'SET_ATTENTION_STEP_TO_16'`: Very useful! Lowest GPU memory utilization, but slowest performance.
         """
@@ -38,7 +42,8 @@ class Context(local):
 
     # hacky approach, but we need to enforce full precision for some devices
     # we also need to force full precision for these devices (haven't implemented this yet):
-    # (('nvidia' in device_name or 'geforce' in device_name) and (' 1660' in device_name or ' 1650' in device_name)) or ('Quadro T2000' in device_name)
+    # (('nvidia' in device_name or 'geforce' in device_name) and (' 1660' in device_name or ' 1650' in device_name))
+    # or ('Quadro T2000' in device_name)
     @property
     def device(self):
         return self._device

--- a/sdkit/__init__.py
+++ b/sdkit/__init__.py
@@ -1,8 +1,9 @@
 from threading import local
 
+
 class Context(local):
     def __init__(self) -> None:
-        self._device: str = 'cuda:0'
+        self._device: str = "cuda:0"
         self._half_precision: bool = True
         self._vram_usage_level = None
 
@@ -12,7 +13,7 @@ class Context(local):
 
         self.device_name: str = None
         self.vram_optimizations: set = set()
-        '''
+        """
         **Do not change this unless you know what you're doing!** Instead set `context.vram_usage_level` to `'low'`, `'balanced'` or `'high'`.
 
         Possible values:
@@ -32,8 +33,8 @@ class Context(local):
         it consumes about 1 GB more than `'KEEP_ENTIRE_MODEL_IN_CPU'`, for a much faster rendering performance.
 
         * `'SET_ATTENTION_STEP_TO_16'`: Very useful! Lowest GPU memory utilization, but slowest performance.
-        '''
-        self.vram_usage_level = 'balanced'
+        """
+        self.vram_usage_level = "balanced"
 
     # hacky approach, but we need to enforce full precision for some devices
     # we also need to force full precision for these devices (haven't implemented this yet):
@@ -45,9 +46,10 @@ class Context(local):
     @device.setter
     def device(self, d):
         self._device = d
-        if d == 'cpu':
+        if d == "cpu":
             from sdkit.utils import log
-            log.info('forcing full precision for device: cpu')
+
+            log.info("forcing full precision for device: cpu")
             self._half_precision = False
 
     @property
@@ -56,7 +58,7 @@ class Context(local):
 
     @half_precision.setter
     def half_precision(self, h):
-        self._half_precision = h if self._device != 'cpu' else False
+        self._half_precision = h if self._device != "cpu" else False
 
     @property
     def vram_usage_level(self):
@@ -66,9 +68,9 @@ class Context(local):
     def vram_usage_level(self, level):
         self._vram_usage_level = level
 
-        if level == 'low':
-            self.vram_optimizations = {'KEEP_ENTIRE_MODEL_IN_CPU', 'SET_ATTENTION_STEP_TO_16'}
-        elif level == 'balanced':
-            self.vram_optimizations = {'KEEP_FS_AND_CS_IN_CPU', 'SET_ATTENTION_STEP_TO_16'}
-        elif level == 'high':
-            self.vram_optimizations = {'SET_ATTENTION_STEP_TO_2'}
+        if level == "low":
+            self.vram_optimizations = {"KEEP_ENTIRE_MODEL_IN_CPU", "SET_ATTENTION_STEP_TO_16"}
+        elif level == "balanced":
+            self.vram_optimizations = {"KEEP_FS_AND_CS_IN_CPU", "SET_ATTENTION_STEP_TO_16"}
+        elif level == "high":
+            self.vram_optimizations = {"SET_ATTENTION_STEP_TO_2"}

--- a/sdkit/__init__.py
+++ b/sdkit/__init__.py
@@ -1,8 +1,9 @@
 from threading import local
 
+
 class Context(local):
     def __init__(self) -> None:
-        self._device: str = 'cuda:0'
+        self._device: str = "cuda:0"
         self._half_precision: bool = True
         self._vram_usage_level = None
 
@@ -12,7 +13,7 @@ class Context(local):
 
         self.device_name: str = None
         self.vram_optimizations: set = set()
-        '''
+        """
         **Do not change this unless you know what you're doing!** Instead set `context.vram_usage_level` to `'low'`, `'balanced'` or `'high'`.
 
         Possible values:
@@ -32,8 +33,8 @@ class Context(local):
         it consumes about 1 GB more than `'KEEP_ENTIRE_MODEL_IN_CPU'`, for a much faster rendering performance.
 
         * `'SET_ATTENTION_STEP_TO_16'`: Very useful! Lowest GPU memory utilization, but slowest performance.
-        '''
-        self.vram_usage_level = 'balanced'
+        """
+        self.vram_usage_level = "balanced"
 
     # hacky approach, but we need to enforce full precision for some devices
     # we also need to force full precision for these devices (haven't implemented this yet):
@@ -45,9 +46,10 @@ class Context(local):
     @device.setter
     def device(self, d):
         self._device = d
-        if d == 'cpu':
+        if d == "cpu":
             from sdkit.utils import log
-            log.info('forcing full precision for device: cpu')
+
+            log.info("forcing full precision for device: cpu")
             self._half_precision = False
 
     @property
@@ -56,7 +58,7 @@ class Context(local):
 
     @half_precision.setter
     def half_precision(self, h):
-        self._half_precision = h if self._device != 'cpu' else False
+        self._half_precision = h if self._device != "cpu" else False
 
     @property
     def vram_usage_level(self):
@@ -66,9 +68,15 @@ class Context(local):
     def vram_usage_level(self, level):
         self._vram_usage_level = level
 
-        if level == 'low':
-            self.vram_optimizations = {'KEEP_ENTIRE_MODEL_IN_CPU', 'SET_ATTENTION_STEP_TO_16'}
-        elif level == 'balanced':
-            self.vram_optimizations = {'KEEP_FS_AND_CS_IN_CPU', 'SET_ATTENTION_STEP_TO_16'}
-        elif level == 'high':
-            self.vram_optimizations = {'SET_ATTENTION_STEP_TO_2'}
+        if level == "low":
+            self.vram_optimizations = {
+                "KEEP_ENTIRE_MODEL_IN_CPU",
+                "SET_ATTENTION_STEP_TO_16",
+            }
+        elif level == "balanced":
+            self.vram_optimizations = {
+                "KEEP_FS_AND_CS_IN_CPU",
+                "SET_ATTENTION_STEP_TO_16",
+            }
+        elif level == "high":
+            self.vram_optimizations = {"SET_ATTENTION_STEP_TO_2"}

--- a/sdkit/__init__.py
+++ b/sdkit/__init__.py
@@ -1,9 +1,8 @@
 from threading import local
 
-
 class Context(local):
     def __init__(self) -> None:
-        self._device: str = "cuda:0"
+        self._device: str = 'cuda:0'
         self._half_precision: bool = True
         self._vram_usage_level = None
 
@@ -13,37 +12,32 @@ class Context(local):
 
         self.device_name: str = None
         self.vram_optimizations: set = set()
-        """
-        **Do not change this unless you know what you're doing!**
-        Instead set `context.vram_usage_level` to `'low'`, `'balanced'` or `'high'`.
+        '''
+        **Do not change this unless you know what you're doing!** Instead set `context.vram_usage_level` to `'low'`, `'balanced'` or `'high'`.
 
         Possible values:
         * Empty set: Fastest, and consumes the maximum amount of VRAM.
 
-        * `'KEEP_FS_AND_CS_IN_CPU'`: Honestly, not very useful.
-            Slightly slower than `None`, but consumes slightly less VRAM than `None`.
-            For the sd-v1-4 model, it consumes atleast 8% less VRAM than `None`. It moves the first_stage and cond_stage
-            to the CPU, and keeps the rest of the model in GPU (input, middle and output blocks). The first_stage
-            and cond_stage will be moved to the GPU only when they are needed, and moved back to the CPU after that.
+        * `'KEEP_FS_AND_CS_IN_CPU'`: Honestly, not very useful. Slightly slower than `None`, but consumes slightly less VRAM than `None`.
+        For the sd-v1-4 model, it consumes atleast 8% less VRAM than `None`. It moves the first_stage and cond_stage
+        to the CPU, and keeps the rest of the model in GPU (input, middle and output blocks). The first_stage
+        and cond_stage will be moved to the GPU only when they are needed, and moved back to the CPU after that.
 
-        * `'KEEP_ENTIRE_MODEL_IN_CPU'`: Very useful! Slowest option, consumes the least amount of VRAM.
-            For the sd-v1-4 model,
-            it consumes atleast 52% less VRAM than using no optimizations. Along with the first_stage and cond_stage,
-            it also moves the input, middle and output blocks to the CPU (effectively, the entire model is kept in CPU).
-            Each block will be moved to the GPU only when they are needed, and moved back to the CPU after that.
+        * `'KEEP_ENTIRE_MODEL_IN_CPU'`: Very useful! Slowest option, consumes the least amount of VRAM. For the sd-v1-4 model,
+        it consumes atleast 52% less VRAM than using no optimizations. Along with the first_stage and cond_stage, it also moves the input,
+        middle and output blocks to the CPU (effectively, the entire model is kept in CPU). Each block will be moved
+        to the GPU only when they are needed, and moved back to the CPU after that.
 
-        * `'SET_ATTENTION_STEP_TO_4'`: Pretty useful! Fairly fast performance, consumes a medium amount of VRAM.
-            For the sd-v1-4 model,
-            it consumes about 1 GB more than `'KEEP_ENTIRE_MODEL_IN_CPU'`, for a much faster rendering performance.
+        * `'SET_ATTENTION_STEP_TO_4'`: Pretty useful! Fairly fast performance, consumes a medium amount of VRAM. For the sd-v1-4 model,
+        it consumes about 1 GB more than `'KEEP_ENTIRE_MODEL_IN_CPU'`, for a much faster rendering performance.
 
         * `'SET_ATTENTION_STEP_TO_16'`: Very useful! Lowest GPU memory utilization, but slowest performance.
-        """
-        self.vram_usage_level = "balanced"
+        '''
+        self.vram_usage_level = 'balanced'
 
     # hacky approach, but we need to enforce full precision for some devices
     # we also need to force full precision for these devices (haven't implemented this yet):
-    # (('nvidia' in device_name or 'geforce' in device_name) and (' 1660' in device_name or ' 1650' in device_name))
-    # or ('Quadro T2000' in device_name)
+    # (('nvidia' in device_name or 'geforce' in device_name) and (' 1660' in device_name or ' 1650' in device_name)) or ('Quadro T2000' in device_name)
     @property
     def device(self):
         return self._device
@@ -51,10 +45,9 @@ class Context(local):
     @device.setter
     def device(self, d):
         self._device = d
-        if d == "cpu":
+        if d == 'cpu':
             from sdkit.utils import log
-
-            log.info("forcing full precision for device: cpu")
+            log.info('forcing full precision for device: cpu')
             self._half_precision = False
 
     @property
@@ -63,7 +56,7 @@ class Context(local):
 
     @half_precision.setter
     def half_precision(self, h):
-        self._half_precision = h if self._device != "cpu" else False
+        self._half_precision = h if self._device != 'cpu' else False
 
     @property
     def vram_usage_level(self):
@@ -73,15 +66,9 @@ class Context(local):
     def vram_usage_level(self, level):
         self._vram_usage_level = level
 
-        if level == "low":
-            self.vram_optimizations = {
-                "KEEP_ENTIRE_MODEL_IN_CPU",
-                "SET_ATTENTION_STEP_TO_16",
-            }
-        elif level == "balanced":
-            self.vram_optimizations = {
-                "KEEP_FS_AND_CS_IN_CPU",
-                "SET_ATTENTION_STEP_TO_16",
-            }
-        elif level == "high":
-            self.vram_optimizations = {"SET_ATTENTION_STEP_TO_2"}
+        if level == 'low':
+            self.vram_optimizations = {'KEEP_ENTIRE_MODEL_IN_CPU', 'SET_ATTENTION_STEP_TO_16'}
+        elif level == 'balanced':
+            self.vram_optimizations = {'KEEP_FS_AND_CS_IN_CPU', 'SET_ATTENTION_STEP_TO_16'}
+        elif level == 'high':
+            self.vram_optimizations = {'SET_ATTENTION_STEP_TO_2'}

--- a/sdkit/filter/__init__.py
+++ b/sdkit/filter/__init__.py
@@ -1,0 +1,1 @@
+from .apply_filters import apply_filters

--- a/sdkit/filter/__init__.py
+++ b/sdkit/filter/__init__.py
@@ -1,1 +1,0 @@
-from .apply_filters import apply_filters

--- a/sdkit/filter/apply_filters.py
+++ b/sdkit/filter/apply_filters.py
@@ -13,16 +13,15 @@ def apply_filters(context: Context, filters, images, **kwargs):
     """
     * context: Context
     * filters: filter_type (string) or list of strings
-    * images: str or PIL.Image or list of str/PIL.Image - image to filter. if a string is passed, it needs to be a base64-encoded image
+    * images: str or PIL.Image or list of str/PIL.Image - image to filter.
+              if a string is passed, it needs to be a base64-encoded image
 
     returns: PIL.Image - filtered image
     """
     images = images if isinstance(images, list) else [images]
     filters = filters if isinstance(filters, list) else [filters]
 
-    return [
-        apply_filter_single_image(context, filters, image, **kwargs) for image in images
-    ]
+    return [apply_filter_single_image(context, filters, image, **kwargs) for image in images]
 
 
 def apply_filter_single_image(context, filters, image, **kwargs):

--- a/sdkit/filter/apply_filters.py
+++ b/sdkit/filter/apply_filters.py
@@ -4,28 +4,30 @@ from sdkit import Context
 from sdkit.utils import base64_str_to_img, log, gc
 
 filter_modules = {
-    'gfpgan': gfpgan,
-    'realesrgan': realesrgan,
+    "gfpgan": gfpgan,
+    "realesrgan": realesrgan,
 }
 
+
 def apply_filters(context: Context, filters, images, **kwargs):
-    '''
+    """
     * context: Context
     * filters: filter_type (string) or list of strings
     * images: str or PIL.Image or list of str/PIL.Image - image to filter. if a string is passed, it needs to be a base64-encoded image
 
     returns: PIL.Image - filtered image
-    '''
+    """
     images = images if isinstance(images, list) else [images]
     filters = filters if isinstance(filters, list) else [filters]
 
     return [apply_filter_single_image(context, filters, image, **kwargs) for image in images]
 
+
 def apply_filter_single_image(context, filters, image, **kwargs):
     image = base64_str_to_img(image) if isinstance(image, str) else image
 
     for filter_type in filters:
-        log.info(f'Applying {filter_type}...')
+        log.info(f"Applying {filter_type}...")
         gc(context)
 
         image = filter_modules[filter_type].apply(context, image, **kwargs)

--- a/sdkit/filter/apply_filters.py
+++ b/sdkit/filter/apply_filters.py
@@ -4,28 +4,32 @@ from sdkit import Context
 from sdkit.utils import base64_str_to_img, log, gc
 
 filter_modules = {
-    'gfpgan': gfpgan,
-    'realesrgan': realesrgan,
+    "gfpgan": gfpgan,
+    "realesrgan": realesrgan,
 }
 
+
 def apply_filters(context: Context, filters, images, **kwargs):
-    '''
+    """
     * context: Context
     * filters: filter_type (string) or list of strings
     * images: str or PIL.Image or list of str/PIL.Image - image to filter. if a string is passed, it needs to be a base64-encoded image
 
     returns: PIL.Image - filtered image
-    '''
+    """
     images = images if isinstance(images, list) else [images]
     filters = filters if isinstance(filters, list) else [filters]
 
-    return [apply_filter_single_image(context, filters, image, **kwargs) for image in images]
+    return [
+        apply_filter_single_image(context, filters, image, **kwargs) for image in images
+    ]
+
 
 def apply_filter_single_image(context, filters, image, **kwargs):
     image = base64_str_to_img(image) if isinstance(image, str) else image
 
     for filter_type in filters:
-        log.info(f'Applying {filter_type}...')
+        log.info(f"Applying {filter_type}...")
         gc(context)
 
         image = filter_modules[filter_type].apply(context, image, **kwargs)

--- a/sdkit/filter/apply_filters.py
+++ b/sdkit/filter/apply_filters.py
@@ -1,34 +1,31 @@
-from sdkit import Context
-from sdkit.utils import base64_str_to_img, gc, log
-
 from . import gfpgan, realesrgan
 
+from sdkit import Context
+from sdkit.utils import base64_str_to_img, log, gc
+
 filter_modules = {
-    "gfpgan": gfpgan,
-    "realesrgan": realesrgan,
+    'gfpgan': gfpgan,
+    'realesrgan': realesrgan,
 }
 
-
 def apply_filters(context: Context, filters, images, **kwargs):
-    """
+    '''
     * context: Context
     * filters: filter_type (string) or list of strings
-    * images: str or PIL.Image or list of str/PIL.Image - image to filter.
-              if a string is passed, it needs to be a base64-encoded image
+    * images: str or PIL.Image or list of str/PIL.Image - image to filter. if a string is passed, it needs to be a base64-encoded image
 
     returns: PIL.Image - filtered image
-    """
+    '''
     images = images if isinstance(images, list) else [images]
     filters = filters if isinstance(filters, list) else [filters]
 
     return [apply_filter_single_image(context, filters, image, **kwargs) for image in images]
 
-
 def apply_filter_single_image(context, filters, image, **kwargs):
     image = base64_str_to_img(image) if isinstance(image, str) else image
 
     for filter_type in filters:
-        log.info(f"Applying {filter_type}...")
+        log.info(f'Applying {filter_type}...')
         gc(context)
 
         image = filter_modules[filter_type].apply(context, image, **kwargs)

--- a/sdkit/filter/apply_filters.py
+++ b/sdkit/filter/apply_filters.py
@@ -1,7 +1,7 @@
-from . import gfpgan, realesrgan
-
 from sdkit import Context
-from sdkit.utils import base64_str_to_img, log, gc
+from sdkit.utils import base64_str_to_img, gc, log
+
+from . import gfpgan, realesrgan
 
 filter_modules = {
     "gfpgan": gfpgan,

--- a/sdkit/filter/gfpgan.py
+++ b/sdkit/filter/gfpgan.py
@@ -1,7 +1,8 @@
-import torch
-import numpy as np
-from PIL import Image
 from threading import Lock
+
+import numpy as np
+import torch
+from PIL import Image
 
 from sdkit import Context
 

--- a/sdkit/filter/gfpgan.py
+++ b/sdkit/filter/gfpgan.py
@@ -6,16 +6,12 @@ from PIL import Image
 
 from sdkit import Context
 
-gfpgan_temp_device_lock = (
-    Lock()
-)  # workaround: gfpgan currently can only start on one device at a time.
+gfpgan_temp_device_lock = Lock()  # workaround: gfpgan currently can only start on one device at a time.
 
 
 def apply(context: Context, image, **kwargs):
     # This lock is only ever used here. No need to use timeout for the request. Should never deadlock.
-    with (
-        gfpgan_temp_device_lock
-    ):  # Wait for any other devices to complete before starting.
+    with gfpgan_temp_device_lock:  # Wait for any other devices to complete before starting.
         # hack for a bug in facexlib: https://github.com/xinntao/facexlib/pull/19/files
         from facexlib.detection import retinaface
 

--- a/sdkit/filter/gfpgan.py
+++ b/sdkit/filter/gfpgan.py
@@ -5,20 +5,24 @@ from threading import Lock
 
 from sdkit import Context
 
-gfpgan_temp_device_lock = Lock() # workaround: gfpgan currently can only start on one device at a time.
+gfpgan_temp_device_lock = Lock()  # workaround: gfpgan currently can only start on one device at a time.
+
 
 def apply(context: Context, image, **kwargs):
     # This lock is only ever used here. No need to use timeout for the request. Should never deadlock.
-    with gfpgan_temp_device_lock: # Wait for any other devices to complete before starting.
+    with gfpgan_temp_device_lock:  # Wait for any other devices to complete before starting.
         # hack for a bug in facexlib: https://github.com/xinntao/facexlib/pull/19/files
         from facexlib.detection import retinaface
+
         retinaface.device = torch.device(context.device)
 
-        image = image.convert('RGB')
-        image = np.array(image, dtype=np.uint8)[...,::-1]
+        image = image.convert("RGB")
+        image = np.array(image, dtype=np.uint8)[..., ::-1]
 
-        _, _, output = context.models['gfpgan'].enhance(image, has_aligned=False, only_center_face=False, paste_back=True)
-        output = output[:,:,::-1]
+        _, _, output = context.models["gfpgan"].enhance(
+            image, has_aligned=False, only_center_face=False, paste_back=True
+        )
+        output = output[:, :, ::-1]
         output = Image.fromarray(output)
 
         return output

--- a/sdkit/filter/gfpgan.py
+++ b/sdkit/filter/gfpgan.py
@@ -1,29 +1,24 @@
-from threading import Lock
-
-import numpy as np
 import torch
+import numpy as np
 from PIL import Image
+from threading import Lock
 
 from sdkit import Context
 
-gfpgan_temp_device_lock = Lock()  # workaround: gfpgan currently can only start on one device at a time.
-
+gfpgan_temp_device_lock = Lock() # workaround: gfpgan currently can only start on one device at a time.
 
 def apply(context: Context, image, **kwargs):
     # This lock is only ever used here. No need to use timeout for the request. Should never deadlock.
-    with gfpgan_temp_device_lock:  # Wait for any other devices to complete before starting.
+    with gfpgan_temp_device_lock: # Wait for any other devices to complete before starting.
         # hack for a bug in facexlib: https://github.com/xinntao/facexlib/pull/19/files
         from facexlib.detection import retinaface
-
         retinaface.device = torch.device(context.device)
 
-        image = image.convert("RGB")
-        image = np.array(image, dtype=np.uint8)[..., ::-1]
+        image = image.convert('RGB')
+        image = np.array(image, dtype=np.uint8)[...,::-1]
 
-        _, _, output = context.models["gfpgan"].enhance(
-            image, has_aligned=False, only_center_face=False, paste_back=True
-        )
-        output = output[:, :, ::-1]
+        _, _, output = context.models['gfpgan'].enhance(image, has_aligned=False, only_center_face=False, paste_back=True)
+        output = output[:,:,::-1]
         output = Image.fromarray(output)
 
         return output

--- a/sdkit/filter/gfpgan.py
+++ b/sdkit/filter/gfpgan.py
@@ -5,20 +5,28 @@ from threading import Lock
 
 from sdkit import Context
 
-gfpgan_temp_device_lock = Lock() # workaround: gfpgan currently can only start on one device at a time.
+gfpgan_temp_device_lock = (
+    Lock()
+)  # workaround: gfpgan currently can only start on one device at a time.
+
 
 def apply(context: Context, image, **kwargs):
     # This lock is only ever used here. No need to use timeout for the request. Should never deadlock.
-    with gfpgan_temp_device_lock: # Wait for any other devices to complete before starting.
+    with (
+        gfpgan_temp_device_lock
+    ):  # Wait for any other devices to complete before starting.
         # hack for a bug in facexlib: https://github.com/xinntao/facexlib/pull/19/files
         from facexlib.detection import retinaface
+
         retinaface.device = torch.device(context.device)
 
-        image = image.convert('RGB')
-        image = np.array(image, dtype=np.uint8)[...,::-1]
+        image = image.convert("RGB")
+        image = np.array(image, dtype=np.uint8)[..., ::-1]
 
-        _, _, output = context.models['gfpgan'].enhance(image, has_aligned=False, only_center_face=False, paste_back=True)
-        output = output[:,:,::-1]
+        _, _, output = context.models["gfpgan"].enhance(
+            image, has_aligned=False, only_center_face=False, paste_back=True
+        )
+        output = output[:, :, ::-1]
         output = Image.fromarray(output)
 
         return output

--- a/sdkit/filter/realesrgan.py
+++ b/sdkit/filter/realesrgan.py
@@ -3,12 +3,13 @@ from PIL import Image
 
 from sdkit import Context
 
-def apply(context: Context, image, scale=4, **kwargs):
-    image = image.convert('RGB')
-    image = np.array(image, dtype=np.uint8)[...,::-1]
 
-    output, _ = context.models['realesrgan'].enhance(image, outscale=scale)
-    output = output[:,:,::-1]
+def apply(context: Context, image, scale=4, **kwargs):
+    image = image.convert("RGB")
+    image = np.array(image, dtype=np.uint8)[..., ::-1]
+
+    output, _ = context.models["realesrgan"].enhance(image, outscale=scale)
+    output = output[:, :, ::-1]
     output = Image.fromarray(output)
 
     return output

--- a/sdkit/filter/realesrgan.py
+++ b/sdkit/filter/realesrgan.py
@@ -3,13 +3,12 @@ from PIL import Image
 
 from sdkit import Context
 
-
 def apply(context: Context, image, scale=4, **kwargs):
-    image = image.convert("RGB")
-    image = np.array(image, dtype=np.uint8)[..., ::-1]
+    image = image.convert('RGB')
+    image = np.array(image, dtype=np.uint8)[...,::-1]
 
-    output, _ = context.models["realesrgan"].enhance(image, outscale=scale)
-    output = output[:, :, ::-1]
+    output, _ = context.models['realesrgan'].enhance(image, outscale=scale)
+    output = output[:,:,::-1]
     output = Image.fromarray(output)
 
     return output

--- a/sdkit/generate/__init__.py
+++ b/sdkit/generate/__init__.py
@@ -1,0 +1,3 @@
+from .image_generator import (
+    generate_images,
+)

--- a/sdkit/generate/__init__.py
+++ b/sdkit/generate/__init__.py
@@ -1,1 +1,0 @@
-from .image_generator import generate_images

--- a/sdkit/generate/__init__.py
+++ b/sdkit/generate/__init__.py
@@ -1,1 +1,3 @@
-from .image_generator import generate_images
+from .image_generator import (
+    generate_images,
+)

--- a/sdkit/generate/__init__.py
+++ b/sdkit/generate/__init__.py
@@ -1,3 +1,1 @@
-from .image_generator import (
-    generate_images,
-)
+from .image_generator import generate_images

--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -1,11 +1,17 @@
-import torch
-from tqdm import trange
-from pytorch_lightning import seed_everything
 from contextlib import nullcontext
 
+import torch
+from pytorch_lightning import seed_everything
+from tqdm import trange
+
 from sdkit import Context
-from sdkit.utils import latent_samples_to_images, base64_str_to_img, get_image_latent_and_mask, apply_color_profile
-from sdkit.utils import gc
+from sdkit.utils import (
+    apply_color_profile,
+    base64_str_to_img,
+    gc,
+    get_image_latent_and_mask,
+    latent_samples_to_images,
+)
 
 from .prompt_parser import get_cond_and_uncond
 from .sampler import make_samples

--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -10,31 +10,27 @@ from sdkit.utils import gc
 from .prompt_parser import get_cond_and_uncond
 from .sampler import make_samples
 
+
 def generate_images(
-        context: Context,
-        prompt: str = "",
-        negative_prompt: str = "",
-
-        seed: int = 42,
-        width: int = 512,
-        height: int = 512,
-
-        num_outputs: int = 1,
-        num_inference_steps: int = 25,
-        guidance_scale: float = 7.5,
-
-        init_image = None,
-        init_image_mask = None,
-        prompt_strength: float = 0.8,
-        preserve_init_image_color_profile = False,
-
-        sampler_name: str = "euler_a", # "ddim", "plms", "heun", "euler", "euler_a", "dpm2", "dpm2_a", "lms",
-                                       # "dpm_solver_stability", "dpmpp_2s_a", "dpmpp_2m", "dpmpp_sde", "dpm_fast"
-                                       # "dpm_adaptive"
-        hypernetwork_strength: float = 0,
-
-        callback=None,
-    ):
+    context: Context,
+    prompt: str = "",
+    negative_prompt: str = "",
+    seed: int = 42,
+    width: int = 512,
+    height: int = 512,
+    num_outputs: int = 1,
+    num_inference_steps: int = 25,
+    guidance_scale: float = 7.5,
+    init_image=None,
+    init_image_mask=None,
+    prompt_strength: float = 0.8,
+    preserve_init_image_color_profile=False,
+    sampler_name: str = "euler_a",  # "ddim", "plms", "heun", "euler", "euler_a", "dpm2", "dpm2_a", "lms",
+    # "dpm_solver_stability", "dpmpp_2s_a", "dpmpp_2m", "dpmpp_sde", "dpm_fast"
+    # "dpm_adaptive"
+    hypernetwork_strength: float = 0,
+    callback=None,
+):
     req_args = locals()
 
     try:
@@ -43,27 +39,29 @@ def generate_images(
         seed_everything(seed)
         precision_scope = torch.autocast if context.half_precision and context.device != "cpu" else nullcontext
 
-        if 'stable-diffusion' not in context.models:
-            raise RuntimeError("The model for Stable Diffusion has not been loaded yet! If you've tried to load it, please check the logs above this message for errors (while loading the model).")
+        if "stable-diffusion" not in context.models:
+            raise RuntimeError(
+                "The model for Stable Diffusion has not been loaded yet! If you've tried to load it, please check the logs above this message for errors (while loading the model)."
+            )
 
-        model = context.models['stable-diffusion']
-        if 'hypernetwork' in context.models:
-            context.models['hypernetwork']['hypernetwork_strength'] = hypernetwork_strength
+        model = context.models["stable-diffusion"]
+        if "hypernetwork" in context.models:
+            context.models["hypernetwork"]["hypernetwork_strength"] = hypernetwork_strength
 
         with precision_scope("cuda"):
             cond, uncond = get_cond_and_uncond(prompt, negative_prompt, num_outputs, model)
 
         generate_fn = txt2img if init_image is None else img2img
         common_sampler_params = {
-            'context': context,
-            'sampler_name': sampler_name,
-            'seed': seed,
-            'batch_size': num_outputs,
-            'shape': [4, height // 8, width // 8],
-            'cond': cond,
-            'uncond': uncond,
-            'guidance_scale': guidance_scale,
-            'callback': callback,
+            "context": context,
+            "sampler_name": sampler_name,
+            "seed": seed,
+            "batch_size": num_outputs,
+            "shape": [4, height // 8, width // 8],
+            "cond": cond,
+            "uncond": uncond,
+            "guidance_scale": guidance_scale,
+            "callback": callback,
         }
 
         with torch.no_grad(), precision_scope("cuda"):
@@ -75,27 +73,47 @@ def generate_images(
     finally:
         context.init_image_latent, context.init_image_mask_tensor = None, None
 
+
 def txt2img(params: dict, context: Context, num_inference_steps, **kwargs):
-    params.update({
-        'steps': num_inference_steps,
-    })
+    params.update(
+        {
+            "steps": num_inference_steps,
+        }
+    )
 
     samples = make_samples(**params)
     return latent_samples_to_images(context, samples)
 
-def img2img(params: dict, context: Context, num_inference_steps, num_outputs, width, height, init_image, init_image_mask, prompt_strength, preserve_init_image_color_profile, **kwargs):
+
+def img2img(
+    params: dict,
+    context: Context,
+    num_inference_steps,
+    num_outputs,
+    width,
+    height,
+    init_image,
+    init_image_mask,
+    prompt_strength,
+    preserve_init_image_color_profile,
+    **kwargs,
+):
     init_image = get_image(init_image)
     init_image_mask = get_image(init_image_mask)
 
-    if not hasattr(context, 'init_image_latent') or context.init_image_latent is None:
-        context.init_image_latent, context.init_image_mask_tensor = get_image_latent_and_mask(context, init_image, init_image_mask, width, height, num_outputs)
+    if not hasattr(context, "init_image_latent") or context.init_image_latent is None:
+        context.init_image_latent, context.init_image_mask_tensor = get_image_latent_and_mask(
+            context, init_image, init_image_mask, width, height, num_outputs
+        )
 
-    params.update({
-        'steps': num_inference_steps,
-        'init_image_latent': context.init_image_latent,
-        'mask': context.init_image_mask_tensor,
-        'prompt_strength': prompt_strength,
-    })
+    params.update(
+        {
+            "steps": num_inference_steps,
+            "init_image_latent": context.init_image_latent,
+            "mask": context.init_image_mask_tensor,
+            "prompt_strength": prompt_strength,
+        }
+    )
 
     samples = make_samples(**params)
     images = latent_samples_to_images(context, samples)
@@ -106,14 +124,17 @@ def img2img(params: dict, context: Context, num_inference_steps, num_outputs, wi
 
     return images
 
+
 def get_image(img):
     if not isinstance(img, str):
         return img
 
-    if img.startswith('data:image'):
+    if img.startswith("data:image"):
         return base64_str_to_img(img)
 
     import os
+
     if os.path.exists(img):
         from PIL import Image
+
         return Image.open(img)

--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -1,16 +1,17 @@
-import torch
-from tqdm import trange
-from pytorch_lightning import seed_everything
 from contextlib import nullcontext
+
+import torch
+from pytorch_lightning import seed_everything
+from tqdm import trange
 
 from sdkit import Context
 from sdkit.utils import (
-    latent_samples_to_images,
-    base64_str_to_img,
-    get_image_latent_and_mask,
     apply_color_profile,
+    base64_str_to_img,
+    gc,
+    get_image_latent_and_mask,
+    latent_samples_to_images,
 )
-from sdkit.utils import gc
 
 from .prompt_parser import get_cond_and_uncond
 from .sampler import make_samples

--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -4,66 +4,77 @@ from pytorch_lightning import seed_everything
 from contextlib import nullcontext
 
 from sdkit import Context
-from sdkit.utils import latent_samples_to_images, base64_str_to_img, get_image_latent_and_mask, apply_color_profile
+from sdkit.utils import (
+    latent_samples_to_images,
+    base64_str_to_img,
+    get_image_latent_and_mask,
+    apply_color_profile,
+)
 from sdkit.utils import gc
 
 from .prompt_parser import get_cond_and_uncond
 from .sampler import make_samples
 
+
 def generate_images(
-        context: Context,
-        prompt: str = "",
-        negative_prompt: str = "",
-
-        seed: int = 42,
-        width: int = 512,
-        height: int = 512,
-
-        num_outputs: int = 1,
-        num_inference_steps: int = 25,
-        guidance_scale: float = 7.5,
-
-        init_image = None,
-        init_image_mask = None,
-        prompt_strength: float = 0.8,
-        preserve_init_image_color_profile = False,
-
-        sampler_name: str = "euler_a", # "ddim", "plms", "heun", "euler", "euler_a", "dpm2", "dpm2_a", "lms",
-                                       # "dpm_solver_stability", "dpmpp_2s_a", "dpmpp_2m", "dpmpp_sde", "dpm_fast"
-                                       # "dpm_adaptive"
-        hypernetwork_strength: float = 0,
-
-        callback=None,
-    ):
+    context: Context,
+    prompt: str = "",
+    negative_prompt: str = "",
+    seed: int = 42,
+    width: int = 512,
+    height: int = 512,
+    num_outputs: int = 1,
+    num_inference_steps: int = 25,
+    guidance_scale: float = 7.5,
+    init_image=None,
+    init_image_mask=None,
+    prompt_strength: float = 0.8,
+    preserve_init_image_color_profile=False,
+    sampler_name: str = "euler_a",  # "ddim", "plms", "heun", "euler", "euler_a", "dpm2", "dpm2_a", "lms",
+    # "dpm_solver_stability", "dpmpp_2s_a", "dpmpp_2m", "dpmpp_sde", "dpm_fast"
+    # "dpm_adaptive"
+    hypernetwork_strength: float = 0,
+    callback=None,
+):
     req_args = locals()
 
     try:
         images = []
 
         seed_everything(seed)
-        precision_scope = torch.autocast if context.half_precision and context.device != "cpu" else nullcontext
+        precision_scope = (
+            torch.autocast
+            if context.half_precision and context.device != "cpu"
+            else nullcontext
+        )
 
-        if 'stable-diffusion' not in context.models:
-            raise RuntimeError("The model for Stable Diffusion has not been loaded yet! If you've tried to load it, please check the logs above this message for errors (while loading the model).")
+        if "stable-diffusion" not in context.models:
+            raise RuntimeError(
+                "The model for Stable Diffusion has not been loaded yet! If you've tried to load it, please check the logs above this message for errors (while loading the model)."
+            )
 
-        model = context.models['stable-diffusion']
-        if 'hypernetwork' in context.models:
-            context.models['hypernetwork']['hypernetwork_strength'] = hypernetwork_strength
+        model = context.models["stable-diffusion"]
+        if "hypernetwork" in context.models:
+            context.models["hypernetwork"][
+                "hypernetwork_strength"
+            ] = hypernetwork_strength
 
         with precision_scope("cuda"):
-            cond, uncond = get_cond_and_uncond(prompt, negative_prompt, num_outputs, model)
+            cond, uncond = get_cond_and_uncond(
+                prompt, negative_prompt, num_outputs, model
+            )
 
         generate_fn = txt2img if init_image is None else img2img
         common_sampler_params = {
-            'context': context,
-            'sampler_name': sampler_name,
-            'seed': seed,
-            'batch_size': num_outputs,
-            'shape': [4, height // 8, width // 8],
-            'cond': cond,
-            'uncond': uncond,
-            'guidance_scale': guidance_scale,
-            'callback': callback,
+            "context": context,
+            "sampler_name": sampler_name,
+            "seed": seed,
+            "batch_size": num_outputs,
+            "shape": [4, height // 8, width // 8],
+            "cond": cond,
+            "uncond": uncond,
+            "guidance_scale": guidance_scale,
+            "callback": callback,
         }
 
         with torch.no_grad(), precision_scope("cuda"):
@@ -75,27 +86,50 @@ def generate_images(
     finally:
         context.init_image_latent, context.init_image_mask_tensor = None, None
 
+
 def txt2img(params: dict, context: Context, num_inference_steps, **kwargs):
-    params.update({
-        'steps': num_inference_steps,
-    })
+    params.update(
+        {
+            "steps": num_inference_steps,
+        }
+    )
 
     samples = make_samples(**params)
     return latent_samples_to_images(context, samples)
 
-def img2img(params: dict, context: Context, num_inference_steps, num_outputs, width, height, init_image, init_image_mask, prompt_strength, preserve_init_image_color_profile, **kwargs):
+
+def img2img(
+    params: dict,
+    context: Context,
+    num_inference_steps,
+    num_outputs,
+    width,
+    height,
+    init_image,
+    init_image_mask,
+    prompt_strength,
+    preserve_init_image_color_profile,
+    **kwargs,
+):
     init_image = get_image(init_image)
     init_image_mask = get_image(init_image_mask)
 
-    if not hasattr(context, 'init_image_latent') or context.init_image_latent is None:
-        context.init_image_latent, context.init_image_mask_tensor = get_image_latent_and_mask(context, init_image, init_image_mask, width, height, num_outputs)
+    if not hasattr(context, "init_image_latent") or context.init_image_latent is None:
+        (
+            context.init_image_latent,
+            context.init_image_mask_tensor,
+        ) = get_image_latent_and_mask(
+            context, init_image, init_image_mask, width, height, num_outputs
+        )
 
-    params.update({
-        'steps': num_inference_steps,
-        'init_image_latent': context.init_image_latent,
-        'mask': context.init_image_mask_tensor,
-        'prompt_strength': prompt_strength,
-    })
+    params.update(
+        {
+            "steps": num_inference_steps,
+            "init_image_latent": context.init_image_latent,
+            "mask": context.init_image_mask_tensor,
+            "prompt_strength": prompt_strength,
+        }
+    )
 
     samples = make_samples(**params)
     images = latent_samples_to_images(context, samples)
@@ -106,14 +140,17 @@ def img2img(params: dict, context: Context, num_inference_steps, num_outputs, wi
 
     return images
 
+
 def get_image(img):
     if not isinstance(img, str):
         return img
 
-    if img.startswith('data:image'):
+    if img.startswith("data:image"):
         return base64_str_to_img(img)
 
     import os
+
     if os.path.exists(img):
         from PIL import Image
+
         return Image.open(img)

--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -43,27 +43,21 @@ def generate_images(
         images = []
 
         seed_everything(seed)
-        precision_scope = (
-            torch.autocast
-            if context.half_precision and context.device != "cpu"
-            else nullcontext
-        )
+        precision_scope = torch.autocast if context.half_precision and context.device != "cpu" else nullcontext
 
         if "stable-diffusion" not in context.models:
             raise RuntimeError(
-                "The model for Stable Diffusion has not been loaded yet! If you've tried to load it, please check the logs above this message for errors (while loading the model)."
+                "The model for Stable Diffusion has not been loaded yet! If you've"
+                " tried to load it, please check the logs above this message for errors"
+                " (while loading the model)."
             )
 
         model = context.models["stable-diffusion"]
         if "hypernetwork" in context.models:
-            context.models["hypernetwork"][
-                "hypernetwork_strength"
-            ] = hypernetwork_strength
+            context.models["hypernetwork"]["hypernetwork_strength"] = hypernetwork_strength
 
         with precision_scope("cuda"):
-            cond, uncond = get_cond_and_uncond(
-                prompt, negative_prompt, num_outputs, model
-            )
+            cond, uncond = get_cond_and_uncond(prompt, negative_prompt, num_outputs, model)
 
         generate_fn = txt2img if init_image is None else img2img
         common_sampler_params = {
@@ -119,9 +113,7 @@ def img2img(
         (
             context.init_image_latent,
             context.init_image_mask_tensor,
-        ) = get_image_latent_and_mask(
-            context, init_image, init_image_mask, width, height, num_outputs
-        )
+        ) = get_image_latent_and_mask(context, init_image, init_image_mask, width, height, num_outputs)
 
     params.update(
         {

--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -1,42 +1,40 @@
+import torch
+from tqdm import trange
+from pytorch_lightning import seed_everything
 from contextlib import nullcontext
 
-import torch
-from pytorch_lightning import seed_everything
-from tqdm import trange
-
 from sdkit import Context
-from sdkit.utils import (
-    apply_color_profile,
-    base64_str_to_img,
-    gc,
-    get_image_latent_and_mask,
-    latent_samples_to_images,
-)
+from sdkit.utils import latent_samples_to_images, base64_str_to_img, get_image_latent_and_mask, apply_color_profile
+from sdkit.utils import gc
 
 from .prompt_parser import get_cond_and_uncond
 from .sampler import make_samples
 
-
 def generate_images(
-    context: Context,
-    prompt: str = "",
-    negative_prompt: str = "",
-    seed: int = 42,
-    width: int = 512,
-    height: int = 512,
-    num_outputs: int = 1,
-    num_inference_steps: int = 25,
-    guidance_scale: float = 7.5,
-    init_image=None,
-    init_image_mask=None,
-    prompt_strength: float = 0.8,
-    preserve_init_image_color_profile=False,
-    sampler_name: str = "euler_a",  # "ddim", "plms", "heun", "euler", "euler_a", "dpm2", "dpm2_a", "lms",
-    # "dpm_solver_stability", "dpmpp_2s_a", "dpmpp_2m", "dpmpp_sde", "dpm_fast"
-    # "dpm_adaptive"
-    hypernetwork_strength: float = 0,
-    callback=None,
-):
+        context: Context,
+        prompt: str = "",
+        negative_prompt: str = "",
+
+        seed: int = 42,
+        width: int = 512,
+        height: int = 512,
+
+        num_outputs: int = 1,
+        num_inference_steps: int = 25,
+        guidance_scale: float = 7.5,
+
+        init_image = None,
+        init_image_mask = None,
+        prompt_strength: float = 0.8,
+        preserve_init_image_color_profile = False,
+
+        sampler_name: str = "euler_a", # "ddim", "plms", "heun", "euler", "euler_a", "dpm2", "dpm2_a", "lms",
+                                       # "dpm_solver_stability", "dpmpp_2s_a", "dpmpp_2m", "dpmpp_sde", "dpm_fast"
+                                       # "dpm_adaptive"
+        hypernetwork_strength: float = 0,
+
+        callback=None,
+    ):
     req_args = locals()
 
     try:
@@ -45,31 +43,27 @@ def generate_images(
         seed_everything(seed)
         precision_scope = torch.autocast if context.half_precision and context.device != "cpu" else nullcontext
 
-        if "stable-diffusion" not in context.models:
-            raise RuntimeError(
-                "The model for Stable Diffusion has not been loaded yet! If you've"
-                " tried to load it, please check the logs above this message for errors"
-                " (while loading the model)."
-            )
+        if 'stable-diffusion' not in context.models:
+            raise RuntimeError("The model for Stable Diffusion has not been loaded yet! If you've tried to load it, please check the logs above this message for errors (while loading the model).")
 
-        model = context.models["stable-diffusion"]
-        if "hypernetwork" in context.models:
-            context.models["hypernetwork"]["hypernetwork_strength"] = hypernetwork_strength
+        model = context.models['stable-diffusion']
+        if 'hypernetwork' in context.models:
+            context.models['hypernetwork']['hypernetwork_strength'] = hypernetwork_strength
 
         with precision_scope("cuda"):
             cond, uncond = get_cond_and_uncond(prompt, negative_prompt, num_outputs, model)
 
         generate_fn = txt2img if init_image is None else img2img
         common_sampler_params = {
-            "context": context,
-            "sampler_name": sampler_name,
-            "seed": seed,
-            "batch_size": num_outputs,
-            "shape": [4, height // 8, width // 8],
-            "cond": cond,
-            "uncond": uncond,
-            "guidance_scale": guidance_scale,
-            "callback": callback,
+            'context': context,
+            'sampler_name': sampler_name,
+            'seed': seed,
+            'batch_size': num_outputs,
+            'shape': [4, height // 8, width // 8],
+            'cond': cond,
+            'uncond': uncond,
+            'guidance_scale': guidance_scale,
+            'callback': callback,
         }
 
         with torch.no_grad(), precision_scope("cuda"):
@@ -81,48 +75,27 @@ def generate_images(
     finally:
         context.init_image_latent, context.init_image_mask_tensor = None, None
 
-
 def txt2img(params: dict, context: Context, num_inference_steps, **kwargs):
-    params.update(
-        {
-            "steps": num_inference_steps,
-        }
-    )
+    params.update({
+        'steps': num_inference_steps,
+    })
 
     samples = make_samples(**params)
     return latent_samples_to_images(context, samples)
 
-
-def img2img(
-    params: dict,
-    context: Context,
-    num_inference_steps,
-    num_outputs,
-    width,
-    height,
-    init_image,
-    init_image_mask,
-    prompt_strength,
-    preserve_init_image_color_profile,
-    **kwargs,
-):
+def img2img(params: dict, context: Context, num_inference_steps, num_outputs, width, height, init_image, init_image_mask, prompt_strength, preserve_init_image_color_profile, **kwargs):
     init_image = get_image(init_image)
     init_image_mask = get_image(init_image_mask)
 
-    if not hasattr(context, "init_image_latent") or context.init_image_latent is None:
-        (
-            context.init_image_latent,
-            context.init_image_mask_tensor,
-        ) = get_image_latent_and_mask(context, init_image, init_image_mask, width, height, num_outputs)
+    if not hasattr(context, 'init_image_latent') or context.init_image_latent is None:
+        context.init_image_latent, context.init_image_mask_tensor = get_image_latent_and_mask(context, init_image, init_image_mask, width, height, num_outputs)
 
-    params.update(
-        {
-            "steps": num_inference_steps,
-            "init_image_latent": context.init_image_latent,
-            "mask": context.init_image_mask_tensor,
-            "prompt_strength": prompt_strength,
-        }
-    )
+    params.update({
+        'steps': num_inference_steps,
+        'init_image_latent': context.init_image_latent,
+        'mask': context.init_image_mask_tensor,
+        'prompt_strength': prompt_strength,
+    })
 
     samples = make_samples(**params)
     images = latent_samples_to_images(context, samples)
@@ -133,17 +106,14 @@ def img2img(
 
     return images
 
-
 def get_image(img):
     if not isinstance(img, str):
         return img
 
-    if img.startswith("data:image"):
+    if img.startswith('data:image'):
         return base64_str_to_img(img)
 
     import os
-
     if os.path.exists(img):
         from PIL import Image
-
         return Image.open(img)

--- a/sdkit/generate/prompt_parser.py
+++ b/sdkit/generate/prompt_parser.py
@@ -2,11 +2,13 @@ import torch
 
 from sdkit.utils import log
 
+
 def get_cond_and_uncond(prompt, negative_prompt, batch_size, model):
     cond = parse_prompt(prompt, batch_size, model)
     uncond = parse_prompt(negative_prompt, batch_size, model)
 
     return cond, uncond
+
 
 def parse_prompt(prompt, batch_size, model):
     """
@@ -18,16 +20,19 @@ def parse_prompt(prompt, batch_size, model):
     weights_sum = sum(weights)
 
     for i, subprompt in enumerate(subprompts):
-        result = torch.add(result, model.get_learned_conditioning(batch_size * [subprompt]), alpha=weights[i] / weights_sum)
+        result = torch.add(
+            result, model.get_learned_conditioning(batch_size * [subprompt]), alpha=weights[i] / weights_sum
+        )
 
     if len(subprompts) == 0:
         result = empty_result
 
     return result
 
+
 def split_weighted_subprompts(text):
     """
-    grabs all text up to the first occurrence of ':' 
+    grabs all text up to the first occurrence of ':'
     uses the grabbed text as a sub-prompt, and takes the value following ':' as weight
     if ':' has no value defined, defaults to 1.0
     repeats until no text remaining
@@ -37,33 +42,33 @@ def split_weighted_subprompts(text):
     weights = []
     while remaining > 0:
         if ":" in text:
-            idx = text.index(":") # first occurrence from start
+            idx = text.index(":")  # first occurrence from start
             # grab up to index as sub-prompt
             prompt = text[:idx]
             remaining -= idx
             # remove from main text
-            text = text[idx+1:]
-            # find value for weight 
+            text = text[idx + 1 :]
+            # find value for weight
             if " " in text:
-                idx = text.index(" ") # first occurence
-            else: # no space, read to end
+                idx = text.index(" ")  # first occurence
+            else:  # no space, read to end
                 idx = len(text)
             if idx != 0:
                 try:
                     weight = float(text[:idx])
-                except: # couldn't treat as float
+                except:  # couldn't treat as float
                     log.warn(f"Warning: '{text[:idx]}' is not a value, are you missing a space?")
                     weight = 1.0
-            else: # no value found
+            else:  # no value found
                 weight = 1.0
             # remove from main text
             remaining -= idx
-            text = text[idx+1:]
+            text = text[idx + 1 :]
             # append the sub-prompt and its weight
             prompts.append(prompt)
             weights.append(weight)
-        else: # no : found
-            if len(text) > 0: # there is still text though
+        else:  # no : found
+            if len(text) > 0:  # there is still text though
                 # take remainder as weight 1
                 prompts.append(text)
                 weights.append(1.0)

--- a/sdkit/generate/prompt_parser.py
+++ b/sdkit/generate/prompt_parser.py
@@ -2,13 +2,11 @@ import torch
 
 from sdkit.utils import log
 
-
 def get_cond_and_uncond(prompt, negative_prompt, batch_size, model):
     cond = parse_prompt(prompt, batch_size, model)
     uncond = parse_prompt(negative_prompt, batch_size, model)
 
     return cond, uncond
-
 
 def parse_prompt(prompt, batch_size, model):
     """
@@ -20,21 +18,16 @@ def parse_prompt(prompt, batch_size, model):
     weights_sum = sum(weights)
 
     for i, subprompt in enumerate(subprompts):
-        result = torch.add(
-            result,
-            model.get_learned_conditioning(batch_size * [subprompt]),
-            alpha=weights[i] / weights_sum,
-        )
+        result = torch.add(result, model.get_learned_conditioning(batch_size * [subprompt]), alpha=weights[i] / weights_sum)
 
     if len(subprompts) == 0:
         result = empty_result
 
     return result
 
-
 def split_weighted_subprompts(text):
     """
-    grabs all text up to the first occurrence of ':'
+    grabs all text up to the first occurrence of ':' 
     uses the grabbed text as a sub-prompt, and takes the value following ':' as weight
     if ':' has no value defined, defaults to 1.0
     repeats until no text remaining
@@ -44,33 +37,33 @@ def split_weighted_subprompts(text):
     weights = []
     while remaining > 0:
         if ":" in text:
-            idx = text.index(":")  # first occurrence from start
+            idx = text.index(":") # first occurrence from start
             # grab up to index as sub-prompt
             prompt = text[:idx]
             remaining -= idx
             # remove from main text
-            text = text[idx + 1 :]
-            # find value for weight
+            text = text[idx+1:]
+            # find value for weight 
             if " " in text:
-                idx = text.index(" ")  # first occurence
-            else:  # no space, read to end
+                idx = text.index(" ") # first occurence
+            else: # no space, read to end
                 idx = len(text)
             if idx != 0:
                 try:
                     weight = float(text[:idx])
-                except:  # couldn't treat as float
+                except: # couldn't treat as float
                     log.warn(f"Warning: '{text[:idx]}' is not a value, are you missing a space?")
                     weight = 1.0
-            else:  # no value found
+            else: # no value found
                 weight = 1.0
             # remove from main text
             remaining -= idx
-            text = text[idx + 1 :]
+            text = text[idx+1:]
             # append the sub-prompt and its weight
             prompts.append(prompt)
             weights.append(weight)
-        else:  # no : found
-            if len(text) > 0:  # there is still text though
+        else: # no : found
+            if len(text) > 0: # there is still text though
                 # take remainder as weight 1
                 prompts.append(text)
                 weights.append(1.0)

--- a/sdkit/generate/prompt_parser.py
+++ b/sdkit/generate/prompt_parser.py
@@ -59,9 +59,7 @@ def split_weighted_subprompts(text):
                 try:
                     weight = float(text[:idx])
                 except:  # couldn't treat as float
-                    log.warn(
-                        f"Warning: '{text[:idx]}' is not a value, are you missing a space?"
-                    )
+                    log.warn(f"Warning: '{text[:idx]}' is not a value, are you missing a space?")
                     weight = 1.0
             else:  # no value found
                 weight = 1.0

--- a/sdkit/generate/prompt_parser.py
+++ b/sdkit/generate/prompt_parser.py
@@ -2,11 +2,13 @@ import torch
 
 from sdkit.utils import log
 
+
 def get_cond_and_uncond(prompt, negative_prompt, batch_size, model):
     cond = parse_prompt(prompt, batch_size, model)
     uncond = parse_prompt(negative_prompt, batch_size, model)
 
     return cond, uncond
+
 
 def parse_prompt(prompt, batch_size, model):
     """
@@ -18,16 +20,21 @@ def parse_prompt(prompt, batch_size, model):
     weights_sum = sum(weights)
 
     for i, subprompt in enumerate(subprompts):
-        result = torch.add(result, model.get_learned_conditioning(batch_size * [subprompt]), alpha=weights[i] / weights_sum)
+        result = torch.add(
+            result,
+            model.get_learned_conditioning(batch_size * [subprompt]),
+            alpha=weights[i] / weights_sum,
+        )
 
     if len(subprompts) == 0:
         result = empty_result
 
     return result
 
+
 def split_weighted_subprompts(text):
     """
-    grabs all text up to the first occurrence of ':' 
+    grabs all text up to the first occurrence of ':'
     uses the grabbed text as a sub-prompt, and takes the value following ':' as weight
     if ':' has no value defined, defaults to 1.0
     repeats until no text remaining
@@ -37,33 +44,35 @@ def split_weighted_subprompts(text):
     weights = []
     while remaining > 0:
         if ":" in text:
-            idx = text.index(":") # first occurrence from start
+            idx = text.index(":")  # first occurrence from start
             # grab up to index as sub-prompt
             prompt = text[:idx]
             remaining -= idx
             # remove from main text
-            text = text[idx+1:]
-            # find value for weight 
+            text = text[idx + 1 :]
+            # find value for weight
             if " " in text:
-                idx = text.index(" ") # first occurence
-            else: # no space, read to end
+                idx = text.index(" ")  # first occurence
+            else:  # no space, read to end
                 idx = len(text)
             if idx != 0:
                 try:
                     weight = float(text[:idx])
-                except: # couldn't treat as float
-                    log.warn(f"Warning: '{text[:idx]}' is not a value, are you missing a space?")
+                except:  # couldn't treat as float
+                    log.warn(
+                        f"Warning: '{text[:idx]}' is not a value, are you missing a space?"
+                    )
                     weight = 1.0
-            else: # no value found
+            else:  # no value found
                 weight = 1.0
             # remove from main text
             remaining -= idx
-            text = text[idx+1:]
+            text = text[idx + 1 :]
             # append the sub-prompt and its weight
             prompts.append(prompt)
             weights.append(weight)
-        else: # no : found
-            if len(text) > 0: # there is still text though
+        else:  # no : found
+            if len(text) > 0:  # there is still text though
                 # take remainder as weight 1
                 prompts.append(text)
                 weights.append(1.0)

--- a/sdkit/generate/sampler/__init__.py
+++ b/sdkit/generate/sampler/__init__.py
@@ -1,0 +1,1 @@
+from .sampler_main import make_samples

--- a/sdkit/generate/sampler/__init__.py
+++ b/sdkit/generate/sampler/__init__.py
@@ -1,1 +1,0 @@
-from .sampler_main import make_samples

--- a/sdkit/generate/sampler/default_samplers.py
+++ b/sdkit/generate/sampler/default_samplers.py
@@ -8,56 +8,85 @@ from ldm.models.diffusion.dpm_solver import DPMSolverSampler
 from sdkit import Context
 
 samplers = {
-    'ddim': DDIMSampler,
-    'plms': PLMSSampler,
-    'dpm_solver_stability': DPMSolverSampler,
+    "ddim": DDIMSampler,
+    "plms": PLMSSampler,
+    "dpm_solver_stability": DPMSolverSampler,
 }
 
-def sample(context: Context, sampler_name:str=None, noise: Tensor=None, batch_size: int=1, shape: tuple=(), steps: int=50, cond: Tensor=None, uncond: Tensor=None, guidance_scale: float=0.8, callback=None, **kwargs):
-    model = context.models['stable-diffusion']
-    sample_fn = _sample_txt2img if 'init_image_latent' not in kwargs else _sample_img2img
+
+def sample(
+    context: Context,
+    sampler_name: str = None,
+    noise: Tensor = None,
+    batch_size: int = 1,
+    shape: tuple = (),
+    steps: int = 50,
+    cond: Tensor = None,
+    uncond: Tensor = None,
+    guidance_scale: float = 0.8,
+    callback=None,
+    **kwargs,
+):
+    model = context.models["stable-diffusion"]
+    sample_fn = (
+        _sample_txt2img if "init_image_latent" not in kwargs else _sample_img2img
+    )
 
     common_params = {
-        'S': steps,
-        'batch_size': batch_size,
-        'shape': shape,
-        'conditioning': cond,
-        'verbose': False,
-        'unconditional_guidance_scale': guidance_scale,
-        'unconditional_conditioning': uncond,
-        'eta': 0.,
-        'img_callback': callback,
+        "S": steps,
+        "batch_size": batch_size,
+        "shape": shape,
+        "conditioning": cond,
+        "verbose": False,
+        "unconditional_guidance_scale": guidance_scale,
+        "unconditional_conditioning": uncond,
+        "eta": 0.0,
+        "img_callback": callback,
     }
 
-    samples, _ = sample_fn(model, sampler_name, noise, steps, batch_size, common_params.copy(), **kwargs)
+    samples, _ = sample_fn(
+        model, sampler_name, noise, steps, batch_size, common_params.copy(), **kwargs
+    )
     return samples
+
 
 def _sample_txt2img(model, sampler_name, noise, steps, batch_size, params, **kwargs):
     sampler = samplers[sampler_name](model)
-    params.update({
-        'x_T': noise,
-    })
+    params.update(
+        {
+            "x_T": noise,
+        }
+    )
 
     return sampler.sample(**params)
+
 
 def _sample_img2img(model, sampler_name, noise, steps, batch_size, params, **kwargs):
     sampler = DDIMSampler(model)
 
-    actual_inference_steps = int(steps * kwargs['prompt_strength'])
-    init_image_latent = kwargs['init_image_latent']
-    mask = kwargs.get('mask')
+    actual_inference_steps = int(steps * kwargs["prompt_strength"])
+    init_image_latent = kwargs["init_image_latent"]
+    mask = kwargs.get("mask")
 
-    sampler.make_schedule(ddim_num_steps=steps, ddim_eta=0., verbose=False)
-    z_enc = sampler.stochastic_encode(init_image_latent, torch.tensor([actual_inference_steps] * batch_size).to(model.device), noise=noise)
+    sampler.make_schedule(ddim_num_steps=steps, ddim_eta=0.0, verbose=False)
+    z_enc = sampler.stochastic_encode(
+        init_image_latent,
+        torch.tensor([actual_inference_steps] * batch_size).to(model.device),
+        noise=noise,
+    )
 
-    sampler.make_schedule = (lambda **kwargs: kwargs) # we've already called this, don't call this again from within the sampler
+    sampler.make_schedule = (
+        lambda **kwargs: kwargs
+    )  # we've already called this, don't call this again from within the sampler
     sampler.ddim_timesteps = sampler.ddim_timesteps[:actual_inference_steps]
 
-    params.update({
-        'S': actual_inference_steps,
-        'x_T': z_enc,
-        'x0': init_image_latent if mask is not None else None,
-        'mask': mask,
-    })
+    params.update(
+        {
+            "S": actual_inference_steps,
+            "x_T": z_enc,
+            "x0": init_image_latent if mask is not None else None,
+            "mask": mask,
+        }
+    )
 
     return sampler.sample(**params)

--- a/sdkit/generate/sampler/default_samplers.py
+++ b/sdkit/generate/sampler/default_samplers.py
@@ -8,56 +8,79 @@ from ldm.models.diffusion.dpm_solver import DPMSolverSampler
 from sdkit import Context
 
 samplers = {
-    'ddim': DDIMSampler,
-    'plms': PLMSSampler,
-    'dpm_solver_stability': DPMSolverSampler,
+    "ddim": DDIMSampler,
+    "plms": PLMSSampler,
+    "dpm_solver_stability": DPMSolverSampler,
 }
 
-def sample(context: Context, sampler_name:str=None, noise: Tensor=None, batch_size: int=1, shape: tuple=(), steps: int=50, cond: Tensor=None, uncond: Tensor=None, guidance_scale: float=0.8, callback=None, **kwargs):
-    model = context.models['stable-diffusion']
-    sample_fn = _sample_txt2img if 'init_image_latent' not in kwargs else _sample_img2img
+
+def sample(
+    context: Context,
+    sampler_name: str = None,
+    noise: Tensor = None,
+    batch_size: int = 1,
+    shape: tuple = (),
+    steps: int = 50,
+    cond: Tensor = None,
+    uncond: Tensor = None,
+    guidance_scale: float = 0.8,
+    callback=None,
+    **kwargs,
+):
+    model = context.models["stable-diffusion"]
+    sample_fn = _sample_txt2img if "init_image_latent" not in kwargs else _sample_img2img
 
     common_params = {
-        'S': steps,
-        'batch_size': batch_size,
-        'shape': shape,
-        'conditioning': cond,
-        'verbose': False,
-        'unconditional_guidance_scale': guidance_scale,
-        'unconditional_conditioning': uncond,
-        'eta': 0.,
-        'img_callback': callback,
+        "S": steps,
+        "batch_size": batch_size,
+        "shape": shape,
+        "conditioning": cond,
+        "verbose": False,
+        "unconditional_guidance_scale": guidance_scale,
+        "unconditional_conditioning": uncond,
+        "eta": 0.0,
+        "img_callback": callback,
     }
 
     samples, _ = sample_fn(model, sampler_name, noise, steps, batch_size, common_params.copy(), **kwargs)
     return samples
 
+
 def _sample_txt2img(model, sampler_name, noise, steps, batch_size, params, **kwargs):
     sampler = samplers[sampler_name](model)
-    params.update({
-        'x_T': noise,
-    })
+    params.update(
+        {
+            "x_T": noise,
+        }
+    )
 
     return sampler.sample(**params)
+
 
 def _sample_img2img(model, sampler_name, noise, steps, batch_size, params, **kwargs):
     sampler = DDIMSampler(model)
 
-    actual_inference_steps = int(steps * kwargs['prompt_strength'])
-    init_image_latent = kwargs['init_image_latent']
-    mask = kwargs.get('mask')
+    actual_inference_steps = int(steps * kwargs["prompt_strength"])
+    init_image_latent = kwargs["init_image_latent"]
+    mask = kwargs.get("mask")
 
-    sampler.make_schedule(ddim_num_steps=steps, ddim_eta=0., verbose=False)
-    z_enc = sampler.stochastic_encode(init_image_latent, torch.tensor([actual_inference_steps] * batch_size).to(model.device), noise=noise)
+    sampler.make_schedule(ddim_num_steps=steps, ddim_eta=0.0, verbose=False)
+    z_enc = sampler.stochastic_encode(
+        init_image_latent, torch.tensor([actual_inference_steps] * batch_size).to(model.device), noise=noise
+    )
 
-    sampler.make_schedule = (lambda **kwargs: kwargs) # we've already called this, don't call this again from within the sampler
+    sampler.make_schedule = (
+        lambda **kwargs: kwargs
+    )  # we've already called this, don't call this again from within the sampler
     sampler.ddim_timesteps = sampler.ddim_timesteps[:actual_inference_steps]
 
-    params.update({
-        'S': actual_inference_steps,
-        'x_T': z_enc,
-        'x0': init_image_latent if mask is not None else None,
-        'mask': mask,
-    })
+    params.update(
+        {
+            "S": actual_inference_steps,
+            "x_T": z_enc,
+            "x0": init_image_latent if mask is not None else None,
+            "mask": mask,
+        }
+    )
 
     return sampler.sample(**params)

--- a/sdkit/generate/sampler/default_samplers.py
+++ b/sdkit/generate/sampler/default_samplers.py
@@ -1,9 +1,8 @@
 import torch
-from torch import Tensor
-
 from ldm.models.diffusion.ddim import DDIMSampler
-from ldm.models.diffusion.plms import PLMSSampler
 from ldm.models.diffusion.dpm_solver import DPMSolverSampler
+from ldm.models.diffusion.plms import PLMSSampler
+from torch import Tensor
 
 from sdkit import Context
 

--- a/sdkit/generate/sampler/default_samplers.py
+++ b/sdkit/generate/sampler/default_samplers.py
@@ -1,87 +1,63 @@
 import torch
-from ldm.models.diffusion.ddim import DDIMSampler
-from ldm.models.diffusion.dpm_solver import DPMSolverSampler
-from ldm.models.diffusion.plms import PLMSSampler
 from torch import Tensor
+
+from ldm.models.diffusion.ddim import DDIMSampler
+from ldm.models.diffusion.plms import PLMSSampler
+from ldm.models.diffusion.dpm_solver import DPMSolverSampler
 
 from sdkit import Context
 
 samplers = {
-    "ddim": DDIMSampler,
-    "plms": PLMSSampler,
-    "dpm_solver_stability": DPMSolverSampler,
+    'ddim': DDIMSampler,
+    'plms': PLMSSampler,
+    'dpm_solver_stability': DPMSolverSampler,
 }
 
-
-def sample(
-    context: Context,
-    sampler_name: str = None,
-    noise: Tensor = None,
-    batch_size: int = 1,
-    shape: tuple = (),
-    steps: int = 50,
-    cond: Tensor = None,
-    uncond: Tensor = None,
-    guidance_scale: float = 0.8,
-    callback=None,
-    **kwargs,
-):
-    model = context.models["stable-diffusion"]
-    sample_fn = _sample_txt2img if "init_image_latent" not in kwargs else _sample_img2img
+def sample(context: Context, sampler_name:str=None, noise: Tensor=None, batch_size: int=1, shape: tuple=(), steps: int=50, cond: Tensor=None, uncond: Tensor=None, guidance_scale: float=0.8, callback=None, **kwargs):
+    model = context.models['stable-diffusion']
+    sample_fn = _sample_txt2img if 'init_image_latent' not in kwargs else _sample_img2img
 
     common_params = {
-        "S": steps,
-        "batch_size": batch_size,
-        "shape": shape,
-        "conditioning": cond,
-        "verbose": False,
-        "unconditional_guidance_scale": guidance_scale,
-        "unconditional_conditioning": uncond,
-        "eta": 0.0,
-        "img_callback": callback,
+        'S': steps,
+        'batch_size': batch_size,
+        'shape': shape,
+        'conditioning': cond,
+        'verbose': False,
+        'unconditional_guidance_scale': guidance_scale,
+        'unconditional_conditioning': uncond,
+        'eta': 0.,
+        'img_callback': callback,
     }
 
     samples, _ = sample_fn(model, sampler_name, noise, steps, batch_size, common_params.copy(), **kwargs)
     return samples
 
-
 def _sample_txt2img(model, sampler_name, noise, steps, batch_size, params, **kwargs):
     sampler = samplers[sampler_name](model)
-    params.update(
-        {
-            "x_T": noise,
-        }
-    )
+    params.update({
+        'x_T': noise,
+    })
 
     return sampler.sample(**params)
-
 
 def _sample_img2img(model, sampler_name, noise, steps, batch_size, params, **kwargs):
     sampler = DDIMSampler(model)
 
-    actual_inference_steps = int(steps * kwargs["prompt_strength"])
-    init_image_latent = kwargs["init_image_latent"]
-    mask = kwargs.get("mask")
+    actual_inference_steps = int(steps * kwargs['prompt_strength'])
+    init_image_latent = kwargs['init_image_latent']
+    mask = kwargs.get('mask')
 
-    sampler.make_schedule(ddim_num_steps=steps, ddim_eta=0.0, verbose=False)
-    z_enc = sampler.stochastic_encode(
-        init_image_latent,
-        torch.tensor([actual_inference_steps] * batch_size).to(model.device),
-        noise=noise,
-    )
+    sampler.make_schedule(ddim_num_steps=steps, ddim_eta=0., verbose=False)
+    z_enc = sampler.stochastic_encode(init_image_latent, torch.tensor([actual_inference_steps] * batch_size).to(model.device), noise=noise)
 
-    sampler.make_schedule = (
-        lambda **kwargs: kwargs
-    )  # we've already called this, don't call this again from within the sampler
+    sampler.make_schedule = (lambda **kwargs: kwargs) # we've already called this, don't call this again from within the sampler
     sampler.ddim_timesteps = sampler.ddim_timesteps[:actual_inference_steps]
 
-    params.update(
-        {
-            "S": actual_inference_steps,
-            "x_T": z_enc,
-            "x0": init_image_latent if mask is not None else None,
-            "mask": mask,
-        }
-    )
+    params.update({
+        'S': actual_inference_steps,
+        'x_T': z_enc,
+        'x0': init_image_latent if mask is not None else None,
+        'mask': mask,
+    })
 
     return sampler.sample(**params)

--- a/sdkit/generate/sampler/default_samplers.py
+++ b/sdkit/generate/sampler/default_samplers.py
@@ -27,9 +27,7 @@ def sample(
     **kwargs,
 ):
     model = context.models["stable-diffusion"]
-    sample_fn = (
-        _sample_txt2img if "init_image_latent" not in kwargs else _sample_img2img
-    )
+    sample_fn = _sample_txt2img if "init_image_latent" not in kwargs else _sample_img2img
 
     common_params = {
         "S": steps,
@@ -43,9 +41,7 @@ def sample(
         "img_callback": callback,
     }
 
-    samples, _ = sample_fn(
-        model, sampler_name, noise, steps, batch_size, common_params.copy(), **kwargs
-    )
+    samples, _ = sample_fn(model, sampler_name, noise, steps, batch_size, common_params.copy(), **kwargs)
     return samples
 
 

--- a/sdkit/generate/sampler/k_samplers.py
+++ b/sdkit/generate/sampler/k_samplers.py
@@ -8,49 +8,72 @@ import k_diffusion.external
 from sdkit import Context
 
 samplers = {
-    'euler_a': k_samplers.sample_euler_ancestral,
-    'euler': k_samplers.sample_euler,
-    'lms': k_samplers.sample_lms,
-    'heun': k_samplers.sample_heun,
-    'dpm2': k_samplers.sample_dpm_2,
-    'dpm2_a': k_samplers.sample_dpm_2_ancestral,
-    'dpmpp_2s_a': k_samplers.sample_dpmpp_2s_ancestral,
-    'dpmpp_2m': k_samplers.sample_dpmpp_2m,
-    'dpmpp_sde': k_samplers.sample_dpmpp_sde,
-    'dpm_fast': k_samplers.sample_dpm_fast,
-    'dpm_adaptive': k_samplers.sample_dpm_adaptive,
+    "euler_a": k_samplers.sample_euler_ancestral,
+    "euler": k_samplers.sample_euler,
+    "lms": k_samplers.sample_lms,
+    "heun": k_samplers.sample_heun,
+    "dpm2": k_samplers.sample_dpm_2,
+    "dpm2_a": k_samplers.sample_dpm_2_ancestral,
+    "dpmpp_2s_a": k_samplers.sample_dpmpp_2s_ancestral,
+    "dpmpp_2m": k_samplers.sample_dpmpp_2m,
+    "dpmpp_sde": k_samplers.sample_dpmpp_sde,
+    "dpm_fast": k_samplers.sample_dpm_fast,
+    "dpm_adaptive": k_samplers.sample_dpm_adaptive,
 }
 
-def sample(context: Context, sampler_name:str=None, noise: Tensor=None, batch_size: int=1, shape: tuple=(), steps: int=50, cond: Tensor=None, uncond: Tensor=None, guidance_scale: float=0.8, callback=None, **kwargs):
-    model = context.models['stable-diffusion']
-    denoiser = k_diffusion.external.CompVisVDenoiser if model.parameterization == 'v' else k_diffusion.external.CompVisDenoiser
+
+def sample(
+    context: Context,
+    sampler_name: str = None,
+    noise: Tensor = None,
+    batch_size: int = 1,
+    shape: tuple = (),
+    steps: int = 50,
+    cond: Tensor = None,
+    uncond: Tensor = None,
+    guidance_scale: float = 0.8,
+    callback=None,
+    **kwargs,
+):
+    model = context.models["stable-diffusion"]
+    denoiser = (
+        k_diffusion.external.CompVisVDenoiser
+        if model.parameterization == "v"
+        else k_diffusion.external.CompVisDenoiser
+    )
     wrapped_model = DenoiserWrap(denoiser(model))
     sigmas = wrapped_model.inner_model.get_sigmas(steps)
 
     sample_fn = samplers.get(sampler_name)
-    x_latent = noise # because we only use DDIM for img2img
+    x_latent = noise  # because we only use DDIM for img2img
     x_latent *= sigmas[0]
 
     params = {
-        'model': wrapped_model,
-        'x': x_latent,
-        'callback': (lambda info: callback(info['x'], info['i'])) if callback is not None else None,
-        'extra_args': {
-            'uncond': uncond,
-            'cond': cond,
-            'guidance_scale': guidance_scale,
-        }
+        "model": wrapped_model,
+        "x": x_latent,
+        "callback": (lambda info: callback(info["x"], info["i"]))
+        if callback is not None
+        else None,
+        "extra_args": {
+            "uncond": uncond,
+            "cond": cond,
+            "guidance_scale": guidance_scale,
+        },
     }
 
-    if sampler_name in ('dpm_fast', 'dpm_adaptive'):
-        params['sigma_min'] = sigmas[-2] # sigmas is sorted. the last element is 0, which isn't allowed
-        params['sigma_max'] = sigmas[0]
+    if sampler_name in ("dpm_fast", "dpm_adaptive"):
+        params["sigma_min"] = sigmas[
+            -2
+        ]  # sigmas is sorted. the last element is 0, which isn't allowed
+        params["sigma_max"] = sigmas[0]
 
-        if sampler_name == 'dpm_fast': params['n'] = steps - 1
+        if sampler_name == "dpm_fast":
+            params["n"] = steps - 1
     else:
-        params['sigmas'] = sigmas
+        params["sigmas"] = sigmas
 
     return sample_fn(**params)
+
 
 # based on https://github.com/XmYx/waifu-diffusion-gradio-hosted-by-colab-en/blob/main/scripts/kdiff.py#L109
 class DenoiserWrap(nn.Module):

--- a/sdkit/generate/sampler/k_samplers.py
+++ b/sdkit/generate/sampler/k_samplers.py
@@ -1,9 +1,8 @@
+import k_diffusion.external
+import k_diffusion.sampling as k_samplers
 import torch
 import torch.nn as nn
 from torch import Tensor
-
-import k_diffusion.sampling as k_samplers
-import k_diffusion.external
 
 from sdkit import Context
 

--- a/sdkit/generate/sampler/k_samplers.py
+++ b/sdkit/generate/sampler/k_samplers.py
@@ -8,49 +8,66 @@ import k_diffusion.external
 from sdkit import Context
 
 samplers = {
-    'euler_a': k_samplers.sample_euler_ancestral,
-    'euler': k_samplers.sample_euler,
-    'lms': k_samplers.sample_lms,
-    'heun': k_samplers.sample_heun,
-    'dpm2': k_samplers.sample_dpm_2,
-    'dpm2_a': k_samplers.sample_dpm_2_ancestral,
-    'dpmpp_2s_a': k_samplers.sample_dpmpp_2s_ancestral,
-    'dpmpp_2m': k_samplers.sample_dpmpp_2m,
-    'dpmpp_sde': k_samplers.sample_dpmpp_sde,
-    'dpm_fast': k_samplers.sample_dpm_fast,
-    'dpm_adaptive': k_samplers.sample_dpm_adaptive,
+    "euler_a": k_samplers.sample_euler_ancestral,
+    "euler": k_samplers.sample_euler,
+    "lms": k_samplers.sample_lms,
+    "heun": k_samplers.sample_heun,
+    "dpm2": k_samplers.sample_dpm_2,
+    "dpm2_a": k_samplers.sample_dpm_2_ancestral,
+    "dpmpp_2s_a": k_samplers.sample_dpmpp_2s_ancestral,
+    "dpmpp_2m": k_samplers.sample_dpmpp_2m,
+    "dpmpp_sde": k_samplers.sample_dpmpp_sde,
+    "dpm_fast": k_samplers.sample_dpm_fast,
+    "dpm_adaptive": k_samplers.sample_dpm_adaptive,
 }
 
-def sample(context: Context, sampler_name:str=None, noise: Tensor=None, batch_size: int=1, shape: tuple=(), steps: int=50, cond: Tensor=None, uncond: Tensor=None, guidance_scale: float=0.8, callback=None, **kwargs):
-    model = context.models['stable-diffusion']
-    denoiser = k_diffusion.external.CompVisVDenoiser if model.parameterization == 'v' else k_diffusion.external.CompVisDenoiser
+
+def sample(
+    context: Context,
+    sampler_name: str = None,
+    noise: Tensor = None,
+    batch_size: int = 1,
+    shape: tuple = (),
+    steps: int = 50,
+    cond: Tensor = None,
+    uncond: Tensor = None,
+    guidance_scale: float = 0.8,
+    callback=None,
+    **kwargs,
+):
+    model = context.models["stable-diffusion"]
+    denoiser = (
+        k_diffusion.external.CompVisVDenoiser if model.parameterization == "v" else k_diffusion.external.CompVisDenoiser
+    )
     wrapped_model = DenoiserWrap(denoiser(model))
     sigmas = wrapped_model.inner_model.get_sigmas(steps)
 
     sample_fn = samplers.get(sampler_name)
-    x_latent = noise # because we only use DDIM for img2img
+    x_latent = noise  # because we only use DDIM for img2img
     x_latent *= sigmas[0]
 
     params = {
-        'model': wrapped_model,
-        'x': x_latent,
-        'callback': (lambda info: callback(info['x'], info['i'])) if callback is not None else None,
-        'extra_args': {
-            'uncond': uncond,
-            'cond': cond,
-            'guidance_scale': guidance_scale,
-        }
+        "model": wrapped_model,
+        "x": x_latent,
+        "callback": (lambda info: callback(info["x"], info["i"])) if callback is not None else None,
+        "extra_args": {
+            "uncond": uncond,
+            "cond": cond,
+            "guidance_scale": guidance_scale,
+        },
     }
 
-    if sampler_name in ('dpm_fast', 'dpm_adaptive'):
-        params['sigma_min'] = sigmas[-2] # sigmas is sorted. the last element is 0, which isn't allowed
-        params['sigma_max'] = sigmas[0]
+    if sampler_name in ("dpm_fast", "dpm_adaptive"):
+        params["sigma_min"] = sigmas[-2]  # sigmas is sorted. the last element is 0, which isn't allowed
+        params["sigma_max"] = sigmas[0]
 
-        if sampler_name == 'dpm_fast': params['n'] = steps - 1
+        if sampler_name == "dpm_fast":
+            params["n"] = steps - 1
     else:
-        params['sigmas'] = sigmas
+        params["sigmas"] = sigmas
 
     return sample_fn(**params)
+
 
 # based on https://github.com/XmYx/waifu-diffusion-gradio-hosted-by-colab-en/blob/main/scripts/kdiff.py#L109
 class DenoiserWrap(nn.Module):

--- a/sdkit/generate/sampler/k_samplers.py
+++ b/sdkit/generate/sampler/k_samplers.py
@@ -1,72 +1,56 @@
-import k_diffusion.external
-import k_diffusion.sampling as k_samplers
 import torch
 import torch.nn as nn
 from torch import Tensor
 
+import k_diffusion.sampling as k_samplers
+import k_diffusion.external
+
 from sdkit import Context
 
 samplers = {
-    "euler_a": k_samplers.sample_euler_ancestral,
-    "euler": k_samplers.sample_euler,
-    "lms": k_samplers.sample_lms,
-    "heun": k_samplers.sample_heun,
-    "dpm2": k_samplers.sample_dpm_2,
-    "dpm2_a": k_samplers.sample_dpm_2_ancestral,
-    "dpmpp_2s_a": k_samplers.sample_dpmpp_2s_ancestral,
-    "dpmpp_2m": k_samplers.sample_dpmpp_2m,
-    "dpmpp_sde": k_samplers.sample_dpmpp_sde,
-    "dpm_fast": k_samplers.sample_dpm_fast,
-    "dpm_adaptive": k_samplers.sample_dpm_adaptive,
+    'euler_a': k_samplers.sample_euler_ancestral,
+    'euler': k_samplers.sample_euler,
+    'lms': k_samplers.sample_lms,
+    'heun': k_samplers.sample_heun,
+    'dpm2': k_samplers.sample_dpm_2,
+    'dpm2_a': k_samplers.sample_dpm_2_ancestral,
+    'dpmpp_2s_a': k_samplers.sample_dpmpp_2s_ancestral,
+    'dpmpp_2m': k_samplers.sample_dpmpp_2m,
+    'dpmpp_sde': k_samplers.sample_dpmpp_sde,
+    'dpm_fast': k_samplers.sample_dpm_fast,
+    'dpm_adaptive': k_samplers.sample_dpm_adaptive,
 }
 
-
-def sample(
-    context: Context,
-    sampler_name: str = None,
-    noise: Tensor = None,
-    batch_size: int = 1,
-    shape: tuple = (),
-    steps: int = 50,
-    cond: Tensor = None,
-    uncond: Tensor = None,
-    guidance_scale: float = 0.8,
-    callback=None,
-    **kwargs,
-):
-    model = context.models["stable-diffusion"]
-    denoiser = (
-        k_diffusion.external.CompVisVDenoiser if model.parameterization == "v" else k_diffusion.external.CompVisDenoiser
-    )
+def sample(context: Context, sampler_name:str=None, noise: Tensor=None, batch_size: int=1, shape: tuple=(), steps: int=50, cond: Tensor=None, uncond: Tensor=None, guidance_scale: float=0.8, callback=None, **kwargs):
+    model = context.models['stable-diffusion']
+    denoiser = k_diffusion.external.CompVisVDenoiser if model.parameterization == 'v' else k_diffusion.external.CompVisDenoiser
     wrapped_model = DenoiserWrap(denoiser(model))
     sigmas = wrapped_model.inner_model.get_sigmas(steps)
 
     sample_fn = samplers.get(sampler_name)
-    x_latent = noise  # because we only use DDIM for img2img
+    x_latent = noise # because we only use DDIM for img2img
     x_latent *= sigmas[0]
 
     params = {
-        "model": wrapped_model,
-        "x": x_latent,
-        "callback": (lambda info: callback(info["x"], info["i"])) if callback is not None else None,
-        "extra_args": {
-            "uncond": uncond,
-            "cond": cond,
-            "guidance_scale": guidance_scale,
-        },
+        'model': wrapped_model,
+        'x': x_latent,
+        'callback': (lambda info: callback(info['x'], info['i'])) if callback is not None else None,
+        'extra_args': {
+            'uncond': uncond,
+            'cond': cond,
+            'guidance_scale': guidance_scale,
+        }
     }
 
-    if sampler_name in ("dpm_fast", "dpm_adaptive"):
-        params["sigma_min"] = sigmas[-2]  # sigmas is sorted. the last element is 0, which isn't allowed
-        params["sigma_max"] = sigmas[0]
+    if sampler_name in ('dpm_fast', 'dpm_adaptive'):
+        params['sigma_min'] = sigmas[-2] # sigmas is sorted. the last element is 0, which isn't allowed
+        params['sigma_max'] = sigmas[0]
 
-        if sampler_name == "dpm_fast":
-            params["n"] = steps - 1
+        if sampler_name == 'dpm_fast': params['n'] = steps - 1
     else:
-        params["sigmas"] = sigmas
+        params['sigmas'] = sigmas
 
     return sample_fn(**params)
-
 
 # based on https://github.com/XmYx/waifu-diffusion-gradio-hosted-by-colab-en/blob/main/scripts/kdiff.py#L109
 class DenoiserWrap(nn.Module):

--- a/sdkit/generate/sampler/k_samplers.py
+++ b/sdkit/generate/sampler/k_samplers.py
@@ -36,9 +36,7 @@ def sample(
 ):
     model = context.models["stable-diffusion"]
     denoiser = (
-        k_diffusion.external.CompVisVDenoiser
-        if model.parameterization == "v"
-        else k_diffusion.external.CompVisDenoiser
+        k_diffusion.external.CompVisVDenoiser if model.parameterization == "v" else k_diffusion.external.CompVisDenoiser
     )
     wrapped_model = DenoiserWrap(denoiser(model))
     sigmas = wrapped_model.inner_model.get_sigmas(steps)
@@ -50,9 +48,7 @@ def sample(
     params = {
         "model": wrapped_model,
         "x": x_latent,
-        "callback": (lambda info: callback(info["x"], info["i"]))
-        if callback is not None
-        else None,
+        "callback": (lambda info: callback(info["x"], info["i"])) if callback is not None else None,
         "extra_args": {
             "uncond": uncond,
             "cond": cond,
@@ -61,9 +57,7 @@ def sample(
     }
 
     if sampler_name in ("dpm_fast", "dpm_adaptive"):
-        params["sigma_min"] = sigmas[
-            -2
-        ]  # sigmas is sorted. the last element is 0, which isn't allowed
+        params["sigma_min"] = sigmas[-2]  # sigmas is sorted. the last element is 0, which isn't allowed
         params["sigma_max"] = sigmas[0]
 
         if sampler_name == "dpm_fast":

--- a/sdkit/generate/sampler/sampler_main.py
+++ b/sdkit/generate/sampler/sampler_main.py
@@ -6,20 +6,7 @@ from sdkit.utils import log
 
 from . import default_samplers, k_samplers
 
-
-def make_samples(
-    context: Context,
-    sampler_name: str = None,
-    seed: int = 42,
-    batch_size: int = 1,
-    shape: tuple = (),
-    steps: int = 50,
-    cond: Tensor = None,
-    uncond: Tensor = None,
-    guidance_scale: float = 0.8,
-    callback=None,
-    **kwargs,
-):
+def make_samples(context: Context, sampler_name: str=None, seed: int=42, batch_size: int=1, shape: tuple=(), steps: int=50, cond: Tensor=None, uncond: Tensor=None, guidance_scale: float=0.8, callback=None, **kwargs):
     """
     Common args:
     * context: Context
@@ -34,37 +21,20 @@ def make_samples(
     * callback: function - signature: `callback(x_samples: Tensor, i: int)`
 
     additional args for txt2img:
-
+    
     additional args for img2img:
     * init_image_latent: Tensor
     * mask: Tensor
-    * prompt_strength: float - between 0 and 1.
-        Use 0 to ignore the prompt entirely, or 1 to ignore the init image entirely
+    * prompt_strength: float - between 0 and 1. Use 0 to ignore the prompt entirely, or 1 to ignore the init image entirely
     """
     sampler_module = None
-    if sampler_name in default_samplers.samplers:
-        sampler_module = default_samplers
-    if sampler_name in k_samplers.samplers:
-        sampler_module = k_samplers
-    if sampler_module is None:
-        raise RuntimeError(f'Unknown sampler "{sampler_name}"!')
+    if sampler_name in default_samplers.samplers: sampler_module = default_samplers
+    if sampler_name in k_samplers.samplers: sampler_module = k_samplers
+    if sampler_module is None: raise RuntimeError(f'Unknown sampler "{sampler_name}"!')
 
     noise = make_some_noise(seed, batch_size, shape, context.device)
 
-    return sampler_module.sample(
-        context,
-        sampler_name,
-        noise,
-        batch_size,
-        shape,
-        steps,
-        cond,
-        uncond,
-        guidance_scale,
-        callback,
-        **kwargs,
-    )
-
+    return sampler_module.sample(context, sampler_name, noise, batch_size, shape, steps, cond, uncond, guidance_scale, callback, **kwargs)
 
 def make_some_noise(seed, batch_size, shape, device):
     b1, b2, b3 = shape

--- a/sdkit/generate/sampler/sampler_main.py
+++ b/sdkit/generate/sampler/sampler_main.py
@@ -6,7 +6,20 @@ from sdkit.utils import log
 
 from . import default_samplers, k_samplers
 
-def make_samples(context: Context, sampler_name: str=None, seed: int=42, batch_size: int=1, shape: tuple=(), steps: int=50, cond: Tensor=None, uncond: Tensor=None, guidance_scale: float=0.8, callback=None, **kwargs):
+
+def make_samples(
+    context: Context,
+    sampler_name: str = None,
+    seed: int = 42,
+    batch_size: int = 1,
+    shape: tuple = (),
+    steps: int = 50,
+    cond: Tensor = None,
+    uncond: Tensor = None,
+    guidance_scale: float = 0.8,
+    callback=None,
+    **kwargs,
+):
     """
     Common args:
     * context: Context
@@ -21,20 +34,26 @@ def make_samples(context: Context, sampler_name: str=None, seed: int=42, batch_s
     * callback: function - signature: `callback(x_samples: Tensor, i: int)`
 
     additional args for txt2img:
-    
+
     additional args for img2img:
     * init_image_latent: Tensor
     * mask: Tensor
     * prompt_strength: float - between 0 and 1. Use 0 to ignore the prompt entirely, or 1 to ignore the init image entirely
     """
     sampler_module = None
-    if sampler_name in default_samplers.samplers: sampler_module = default_samplers
-    if sampler_name in k_samplers.samplers: sampler_module = k_samplers
-    if sampler_module is None: raise RuntimeError(f'Unknown sampler "{sampler_name}"!')
+    if sampler_name in default_samplers.samplers:
+        sampler_module = default_samplers
+    if sampler_name in k_samplers.samplers:
+        sampler_module = k_samplers
+    if sampler_module is None:
+        raise RuntimeError(f'Unknown sampler "{sampler_name}"!')
 
     noise = make_some_noise(seed, batch_size, shape, context.device)
 
-    return sampler_module.sample(context, sampler_name, noise, batch_size, shape, steps, cond, uncond, guidance_scale, callback, **kwargs)
+    return sampler_module.sample(
+        context, sampler_name, noise, batch_size, shape, steps, cond, uncond, guidance_scale, callback, **kwargs
+    )
+
 
 def make_some_noise(seed, batch_size, shape, device):
     b1, b2, b3 = shape

--- a/sdkit/generate/sampler/sampler_main.py
+++ b/sdkit/generate/sampler/sampler_main.py
@@ -38,7 +38,8 @@ def make_samples(
     additional args for img2img:
     * init_image_latent: Tensor
     * mask: Tensor
-    * prompt_strength: float - between 0 and 1. Use 0 to ignore the prompt entirely, or 1 to ignore the init image entirely
+    * prompt_strength: float - between 0 and 1.
+        Use 0 to ignore the prompt entirely, or 1 to ignore the init image entirely
     """
     sampler_module = None
     if sampler_name in default_samplers.samplers:

--- a/sdkit/generate/sampler/sampler_main.py
+++ b/sdkit/generate/sampler/sampler_main.py
@@ -6,7 +6,20 @@ from sdkit.utils import log
 
 from . import default_samplers, k_samplers
 
-def make_samples(context: Context, sampler_name: str=None, seed: int=42, batch_size: int=1, shape: tuple=(), steps: int=50, cond: Tensor=None, uncond: Tensor=None, guidance_scale: float=0.8, callback=None, **kwargs):
+
+def make_samples(
+    context: Context,
+    sampler_name: str = None,
+    seed: int = 42,
+    batch_size: int = 1,
+    shape: tuple = (),
+    steps: int = 50,
+    cond: Tensor = None,
+    uncond: Tensor = None,
+    guidance_scale: float = 0.8,
+    callback=None,
+    **kwargs,
+):
     """
     Common args:
     * context: Context
@@ -21,20 +34,36 @@ def make_samples(context: Context, sampler_name: str=None, seed: int=42, batch_s
     * callback: function - signature: `callback(x_samples: Tensor, i: int)`
 
     additional args for txt2img:
-    
+
     additional args for img2img:
     * init_image_latent: Tensor
     * mask: Tensor
     * prompt_strength: float - between 0 and 1. Use 0 to ignore the prompt entirely, or 1 to ignore the init image entirely
     """
     sampler_module = None
-    if sampler_name in default_samplers.samplers: sampler_module = default_samplers
-    if sampler_name in k_samplers.samplers: sampler_module = k_samplers
-    if sampler_module is None: raise RuntimeError(f'Unknown sampler "{sampler_name}"!')
+    if sampler_name in default_samplers.samplers:
+        sampler_module = default_samplers
+    if sampler_name in k_samplers.samplers:
+        sampler_module = k_samplers
+    if sampler_module is None:
+        raise RuntimeError(f'Unknown sampler "{sampler_name}"!')
 
     noise = make_some_noise(seed, batch_size, shape, context.device)
 
-    return sampler_module.sample(context, sampler_name, noise, batch_size, shape, steps, cond, uncond, guidance_scale, callback, **kwargs)
+    return sampler_module.sample(
+        context,
+        sampler_name,
+        noise,
+        batch_size,
+        shape,
+        steps,
+        cond,
+        uncond,
+        guidance_scale,
+        callback,
+        **kwargs,
+    )
+
 
 def make_some_noise(seed, batch_size, shape, device):
     b1, b2, b3 = shape

--- a/sdkit/models/__init__.py
+++ b/sdkit/models/__init__.py
@@ -1,8 +1,17 @@
+from .model_loader import (
+    load_model,
+    unload_model,
+)
+
+from .models_db import (
+    get_model_info_from_db,
+    get_models_db,
+)
+
 from .model_downloader import (
     download_model,
     download_models,
     resolve_downloaded_model_path,
 )
-from .model_loader import load_model, unload_model
-from .models_db import get_model_info_from_db, get_models_db
+
 from .scan_models import scan_model

--- a/sdkit/models/__init__.py
+++ b/sdkit/models/__init__.py
@@ -1,8 +1,0 @@
-from .model_downloader import (
-    download_model,
-    download_models,
-    resolve_downloaded_model_path,
-)
-from .model_loader import load_model, unload_model
-from .models_db import get_model_info_from_db, get_models_db
-from .scan_models import scan_model

--- a/sdkit/models/__init__.py
+++ b/sdkit/models/__init__.py
@@ -1,0 +1,17 @@
+from .model_loader import (
+    load_model,
+    unload_model,
+)
+
+from .models_db import (
+    get_model_info_from_db,
+    get_models_db,
+)
+
+from .model_downloader import (
+    download_model,
+    download_models,
+    resolve_downloaded_model_path,
+)
+
+from .scan_models import scan_model

--- a/sdkit/models/__init__.py
+++ b/sdkit/models/__init__.py
@@ -1,17 +1,8 @@
-from .model_loader import (
-    load_model,
-    unload_model,
-)
-
-from .models_db import (
-    get_model_info_from_db,
-    get_models_db,
-)
-
 from .model_downloader import (
     download_model,
     download_models,
     resolve_downloaded_model_path,
 )
-
+from .model_loader import load_model, unload_model
+from .models_db import get_model_info_from_db, get_models_db
 from .scan_models import scan_model

--- a/sdkit/models/model_downloader.py
+++ b/sdkit/models/model_downloader.py
@@ -3,38 +3,30 @@ from urllib.parse import urlparse
 
 from sdkit.utils import download_file, log
 
-
-def download_models(models: dict, download_base_dir: str = None, subdir_for_model_type=True):
-    """
+def download_models(models: dict, download_base_dir: str=None, subdir_for_model_type=True):
+    '''
     Downloads the requested models (and config files) based on the SDKit models database.
     Resumes incomplete downloads, and shows a progress bar.
 
     Args:
     * models: dict of {string: string or list}. Models to download of `model_type: model_ids`.
-        E.g. `{'stable-diffusion': ['1.4', '1.5-inpainting'], 'gfpgan': '1.3'}`
-        `model_ids` can be a single string, or a list of strings.
+              E.g. `{'stable-diffusion': ['1.4', '1.5-inpainting'], 'gfpgan': '1.3'}`
+              `model_ids` can be a single string, or a list of strings.
     * download_base_dir: str - base directory inside which the models are downloaded.
-        Note: The actual download directorypath will include the `model_type` if `subdir_for_model_type` is `True`.
-        If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
-    * subdir_for_model_type: bool - default True.
-        Saves the downloaded model in a subdirectory (named with the model_type).
-        For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
-        `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork`.
-    """
+              Note: The actual download directorypath will include the `model_type` if `subdir_for_model_type` is `True`.
+              If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
+    * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
+              For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
+              `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
+    '''
     for model_type, model_ids in models.items():
         model_ids = model_ids if isinstance(model_ids, list) else [model_ids]
 
         for model_id in model_ids:
             download_model(model_type, model_id, download_base_dir, subdir_for_model_type)
 
-
-def download_model(
-    model_type: str,
-    model_id: str,
-    download_base_dir: str = None,
-    subdir_for_model_type=True,
-):
-    """
+def download_model(model_type: str, model_id: str, download_base_dir: str=None, subdir_for_model_type=True):
+    '''
     Downloads the requested model (and config file) based on the SDKit models database.
     Resumes incomplete downloads, and shows a progress bar.
 
@@ -42,20 +34,19 @@ def download_model(
     * model_type: str
     * model_id: str
     * download_base_dir: str - base directory inside which the models are downloaded.
-        Note: The actual download directory path will include the `model_type` if `subdir_for_model_type` is `True`.
-        If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
-    * subdir_for_model_type: bool - default True.
-        Saves the downloaded model in a subdirectory (named with the model_type).
-        For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
-        `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork`.
-    """
+              Note: The actual download directory path will include the `model_type` if `subdir_for_model_type` is `True`.
+              If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
+    * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
+              For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
+              `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
+    '''
     download_base_dir = get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type)
     try:
-        model_url, model_file_name = get_url_and_filename(model_type, model_id, url_key="url")
-        config_url, config_file_name = get_url_and_filename(model_type, model_id, url_key="config_url")
+        model_url, model_file_name = get_url_and_filename(model_type, model_id, url_key='url')
+        config_url, config_file_name = get_url_and_filename(model_type, model_id, url_key='config_url')
 
         if model_url is None:
-            log.warn(f"No download url found for model {model_type} {model_id}")
+            log.warn(f'No download url found for model {model_type} {model_id}')
             return
 
         os.makedirs(download_base_dir, exist_ok=True)
@@ -68,44 +59,34 @@ def download_model(
     except Exception as e:
         log.exception(e)
 
-
-def resolve_downloaded_model_path(
-    model_type: str,
-    model_id: str,
-    download_base_dir: str = None,
-    subdir_for_model_type=True,
-):
-    """
+def resolve_downloaded_model_path(model_type: str, model_id: str, download_base_dir: str=None, subdir_for_model_type=True):
+    '''
     Gets the path to the downloaded model file. Returns `None` if a file doesn't exist at the calculated path.
 
     Args:
     * model_type: str
     * model_id: str
     * download_base_dir: str - base directory inside which the models are downloaded.
-        Note: The actual download directory path will include the `model_type` if `subdir_for_model_type` is `True`.
-        If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
-    * subdir_for_model_type: bool - default True.
-        Saves the downloaded model in a subdirectory (named with the model_type).
-        For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded
-        to `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded
-        to `D:\\models\\hypernetwork` and so on.
-    """
+              Note: The actual download directory path will include the `model_type` if `subdir_for_model_type` is `True`.
+              If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
+    * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
+              For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
+              `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
+    '''
     download_base_dir = get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type)
-    _, file_name = get_url_and_filename(model_type, model_id, url_key="url")
+    _, file_name = get_url_and_filename(model_type, model_id, url_key='url')
     if file_name is None:
         return
 
     file_path = os.path.join(download_base_dir, file_name)
     return file_path if os.path.exists(file_path) else None
 
-
 def get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type):
-    download_base_dir = os.path.join("~", ".cache", "sdkit") if download_base_dir is None else download_base_dir
+    download_base_dir = os.path.join('~', '.cache', 'sdkit') if download_base_dir is None else download_base_dir
     download_base_dir = os.path.join(download_base_dir, model_type) if subdir_for_model_type else download_base_dir
     return os.path.abspath(download_base_dir)
 
-
-def get_url_and_filename(model_type, model_id, url_key="url"):
+def get_url_and_filename(model_type, model_id, url_key='url'):
     from sdkit.models import get_model_info_from_db
 
     model_info = get_model_info_from_db(model_type=model_type, model_id=model_id)

--- a/sdkit/models/model_downloader.py
+++ b/sdkit/models/model_downloader.py
@@ -3,8 +3,9 @@ from urllib.parse import urlparse
 
 from sdkit.utils import download_file, log
 
-def download_models(models: dict, download_base_dir: str=None, subdir_for_model_type=True):
-    '''
+
+def download_models(models: dict, download_base_dir: str = None, subdir_for_model_type=True):
+    """
     Downloads the requested models (and config files) based on the SDKit models database.
     Resumes incomplete downloads, and shows a progress bar.
 
@@ -18,15 +19,16 @@ def download_models(models: dict, download_base_dir: str=None, subdir_for_model_
     * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
               For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
               `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
-    '''
+    """
     for model_type, model_ids in models.items():
         model_ids = model_ids if isinstance(model_ids, list) else [model_ids]
 
         for model_id in model_ids:
             download_model(model_type, model_id, download_base_dir, subdir_for_model_type)
 
-def download_model(model_type: str, model_id: str, download_base_dir: str=None, subdir_for_model_type=True):
-    '''
+
+def download_model(model_type: str, model_id: str, download_base_dir: str = None, subdir_for_model_type=True):
+    """
     Downloads the requested model (and config file) based on the SDKit models database.
     Resumes incomplete downloads, and shows a progress bar.
 
@@ -39,14 +41,14 @@ def download_model(model_type: str, model_id: str, download_base_dir: str=None, 
     * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
               For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
               `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
-    '''
+    """
     download_base_dir = get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type)
     try:
-        model_url, model_file_name = get_url_and_filename(model_type, model_id, url_key='url')
-        config_url, config_file_name = get_url_and_filename(model_type, model_id, url_key='config_url')
+        model_url, model_file_name = get_url_and_filename(model_type, model_id, url_key="url")
+        config_url, config_file_name = get_url_and_filename(model_type, model_id, url_key="config_url")
 
         if model_url is None:
-            log.warn(f'No download url found for model {model_type} {model_id}')
+            log.warn(f"No download url found for model {model_type} {model_id}")
             return
 
         os.makedirs(download_base_dir, exist_ok=True)
@@ -59,8 +61,11 @@ def download_model(model_type: str, model_id: str, download_base_dir: str=None, 
     except Exception as e:
         log.exception(e)
 
-def resolve_downloaded_model_path(model_type: str, model_id: str, download_base_dir: str=None, subdir_for_model_type=True):
-    '''
+
+def resolve_downloaded_model_path(
+    model_type: str, model_id: str, download_base_dir: str = None, subdir_for_model_type=True
+):
+    """
     Gets the path to the downloaded model file. Returns `None` if a file doesn't exist at the calculated path.
 
     Args:
@@ -72,21 +77,23 @@ def resolve_downloaded_model_path(model_type: str, model_id: str, download_base_
     * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
               For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
               `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
-    '''
+    """
     download_base_dir = get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type)
-    _, file_name = get_url_and_filename(model_type, model_id, url_key='url')
+    _, file_name = get_url_and_filename(model_type, model_id, url_key="url")
     if file_name is None:
         return
 
     file_path = os.path.join(download_base_dir, file_name)
     return file_path if os.path.exists(file_path) else None
 
+
 def get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type):
-    download_base_dir = os.path.join('~', '.cache', 'sdkit') if download_base_dir is None else download_base_dir
+    download_base_dir = os.path.join("~", ".cache", "sdkit") if download_base_dir is None else download_base_dir
     download_base_dir = os.path.join(download_base_dir, model_type) if subdir_for_model_type else download_base_dir
     return os.path.abspath(download_base_dir)
 
-def get_url_and_filename(model_type, model_id, url_key='url'):
+
+def get_url_and_filename(model_type, model_id, url_key="url"):
     from sdkit.models import get_model_info_from_db
 
     model_info = get_model_info_from_db(model_type=model_type, model_id=model_id)

--- a/sdkit/models/model_downloader.py
+++ b/sdkit/models/model_downloader.py
@@ -3,8 +3,11 @@ from urllib.parse import urlparse
 
 from sdkit.utils import download_file, log
 
-def download_models(models: dict, download_base_dir: str=None, subdir_for_model_type=True):
-    '''
+
+def download_models(
+    models: dict, download_base_dir: str = None, subdir_for_model_type=True
+):
+    """
     Downloads the requested models (and config files) based on the SDKit models database.
     Resumes incomplete downloads, and shows a progress bar.
 
@@ -18,15 +21,23 @@ def download_models(models: dict, download_base_dir: str=None, subdir_for_model_
     * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
               For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
               `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
-    '''
+    """
     for model_type, model_ids in models.items():
         model_ids = model_ids if isinstance(model_ids, list) else [model_ids]
 
         for model_id in model_ids:
-            download_model(model_type, model_id, download_base_dir, subdir_for_model_type)
+            download_model(
+                model_type, model_id, download_base_dir, subdir_for_model_type
+            )
 
-def download_model(model_type: str, model_id: str, download_base_dir: str=None, subdir_for_model_type=True):
-    '''
+
+def download_model(
+    model_type: str,
+    model_id: str,
+    download_base_dir: str = None,
+    subdir_for_model_type=True,
+):
+    """
     Downloads the requested model (and config file) based on the SDKit models database.
     Resumes incomplete downloads, and shows a progress bar.
 
@@ -39,14 +50,20 @@ def download_model(model_type: str, model_id: str, download_base_dir: str=None, 
     * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
               For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
               `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
-    '''
-    download_base_dir = get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type)
+    """
+    download_base_dir = get_actual_base_dir(
+        model_type, download_base_dir, subdir_for_model_type
+    )
     try:
-        model_url, model_file_name = get_url_and_filename(model_type, model_id, url_key='url')
-        config_url, config_file_name = get_url_and_filename(model_type, model_id, url_key='config_url')
+        model_url, model_file_name = get_url_and_filename(
+            model_type, model_id, url_key="url"
+        )
+        config_url, config_file_name = get_url_and_filename(
+            model_type, model_id, url_key="config_url"
+        )
 
         if model_url is None:
-            log.warn(f'No download url found for model {model_type} {model_id}')
+            log.warn(f"No download url found for model {model_type} {model_id}")
             return
 
         os.makedirs(download_base_dir, exist_ok=True)
@@ -59,8 +76,14 @@ def download_model(model_type: str, model_id: str, download_base_dir: str=None, 
     except Exception as e:
         log.exception(e)
 
-def resolve_downloaded_model_path(model_type: str, model_id: str, download_base_dir: str=None, subdir_for_model_type=True):
-    '''
+
+def resolve_downloaded_model_path(
+    model_type: str,
+    model_id: str,
+    download_base_dir: str = None,
+    subdir_for_model_type=True,
+):
+    """
     Gets the path to the downloaded model file. Returns `None` if a file doesn't exist at the calculated path.
 
     Args:
@@ -72,21 +95,33 @@ def resolve_downloaded_model_path(model_type: str, model_id: str, download_base_
     * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
               For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
               `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
-    '''
-    download_base_dir = get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type)
-    _, file_name = get_url_and_filename(model_type, model_id, url_key='url')
+    """
+    download_base_dir = get_actual_base_dir(
+        model_type, download_base_dir, subdir_for_model_type
+    )
+    _, file_name = get_url_and_filename(model_type, model_id, url_key="url")
     if file_name is None:
         return
 
     file_path = os.path.join(download_base_dir, file_name)
     return file_path if os.path.exists(file_path) else None
 
+
 def get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type):
-    download_base_dir = os.path.join('~', '.cache', 'sdkit') if download_base_dir is None else download_base_dir
-    download_base_dir = os.path.join(download_base_dir, model_type) if subdir_for_model_type else download_base_dir
+    download_base_dir = (
+        os.path.join("~", ".cache", "sdkit")
+        if download_base_dir is None
+        else download_base_dir
+    )
+    download_base_dir = (
+        os.path.join(download_base_dir, model_type)
+        if subdir_for_model_type
+        else download_base_dir
+    )
     return os.path.abspath(download_base_dir)
 
-def get_url_and_filename(model_type, model_id, url_key='url'):
+
+def get_url_and_filename(model_type, model_id, url_key="url"):
     from sdkit.models import get_model_info_from_db
 
     model_info = get_model_info_from_db(model_type=model_type, model_id=model_id)

--- a/sdkit/models/model_downloader.py
+++ b/sdkit/models/model_downloader.py
@@ -4,31 +4,28 @@ from urllib.parse import urlparse
 from sdkit.utils import download_file, log
 
 
-def download_models(
-    models: dict, download_base_dir: str = None, subdir_for_model_type=True
-):
+def download_models(models: dict, download_base_dir: str = None, subdir_for_model_type=True):
     """
     Downloads the requested models (and config files) based on the SDKit models database.
     Resumes incomplete downloads, and shows a progress bar.
 
     Args:
     * models: dict of {string: string or list}. Models to download of `model_type: model_ids`.
-              E.g. `{'stable-diffusion': ['1.4', '1.5-inpainting'], 'gfpgan': '1.3'}`
-              `model_ids` can be a single string, or a list of strings.
+        E.g. `{'stable-diffusion': ['1.4', '1.5-inpainting'], 'gfpgan': '1.3'}`
+        `model_ids` can be a single string, or a list of strings.
     * download_base_dir: str - base directory inside which the models are downloaded.
-              Note: The actual download directorypath will include the `model_type` if `subdir_for_model_type` is `True`.
-              If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
-    * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
-              For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
-              `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
+        Note: The actual download directorypath will include the `model_type` if `subdir_for_model_type` is `True`.
+        If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
+    * subdir_for_model_type: bool - default True.
+        Saves the downloaded model in a subdirectory (named with the model_type).
+        For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
+        `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork`.
     """
     for model_type, model_ids in models.items():
         model_ids = model_ids if isinstance(model_ids, list) else [model_ids]
 
         for model_id in model_ids:
-            download_model(
-                model_type, model_id, download_base_dir, subdir_for_model_type
-            )
+            download_model(model_type, model_id, download_base_dir, subdir_for_model_type)
 
 
 def download_model(
@@ -45,22 +42,17 @@ def download_model(
     * model_type: str
     * model_id: str
     * download_base_dir: str - base directory inside which the models are downloaded.
-              Note: The actual download directory path will include the `model_type` if `subdir_for_model_type` is `True`.
-              If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
-    * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
-              For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
-              `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
+        Note: The actual download directory path will include the `model_type` if `subdir_for_model_type` is `True`.
+        If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
+    * subdir_for_model_type: bool - default True.
+        Saves the downloaded model in a subdirectory (named with the model_type).
+        For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
+        `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork`.
     """
-    download_base_dir = get_actual_base_dir(
-        model_type, download_base_dir, subdir_for_model_type
-    )
+    download_base_dir = get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type)
     try:
-        model_url, model_file_name = get_url_and_filename(
-            model_type, model_id, url_key="url"
-        )
-        config_url, config_file_name = get_url_and_filename(
-            model_type, model_id, url_key="config_url"
-        )
+        model_url, model_file_name = get_url_and_filename(model_type, model_id, url_key="url")
+        config_url, config_file_name = get_url_and_filename(model_type, model_id, url_key="config_url")
 
         if model_url is None:
             log.warn(f"No download url found for model {model_type} {model_id}")
@@ -90,15 +82,15 @@ def resolve_downloaded_model_path(
     * model_type: str
     * model_id: str
     * download_base_dir: str - base directory inside which the models are downloaded.
-              Note: The actual download directory path will include the `model_type` if `subdir_for_model_type` is `True`.
-              If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
-    * subdir_for_model_type: bool - default True. Saves the downloaded model in a subdirectory (named with the model_type).
-              For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded to
-              `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded to `D:\\models\\hypernetwork` and so on.
+        Note: The actual download directory path will include the `model_type` if `subdir_for_model_type` is `True`.
+        If `download_base_dir` is `None`, it'll use the `~/.cache/sdkit` folder, where `~` is the home or user-folder.
+    * subdir_for_model_type: bool - default True.
+        Saves the downloaded model in a subdirectory (named with the model_type).
+        For e.g. if `download_base_dir` is `D:\\models`, then a `stable-diffusion` type model is downloaded
+        to `D:\\models\\stable-diffusion`, a `hypernetwork` type model is downloaded
+        to `D:\\models\\hypernetwork` and so on.
     """
-    download_base_dir = get_actual_base_dir(
-        model_type, download_base_dir, subdir_for_model_type
-    )
+    download_base_dir = get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type)
     _, file_name = get_url_and_filename(model_type, model_id, url_key="url")
     if file_name is None:
         return
@@ -108,16 +100,8 @@ def resolve_downloaded_model_path(
 
 
 def get_actual_base_dir(model_type, download_base_dir, subdir_for_model_type):
-    download_base_dir = (
-        os.path.join("~", ".cache", "sdkit")
-        if download_base_dir is None
-        else download_base_dir
-    )
-    download_base_dir = (
-        os.path.join(download_base_dir, model_type)
-        if subdir_for_model_type
-        else download_base_dir
-    )
+    download_base_dir = os.path.join("~", ".cache", "sdkit") if download_base_dir is None else download_base_dir
+    download_base_dir = os.path.join(download_base_dir, model_type) if subdir_for_model_type else download_base_dir
     return os.path.abspath(download_base_dir)
 
 

--- a/sdkit/models/model_loader/__init__.py
+++ b/sdkit/models/model_loader/__init__.py
@@ -1,16 +1,16 @@
+from . import hypernetwork
+from . import stable_diffusion, gfpgan, realesrgan, vae
+
 from sdkit import Context
 from sdkit.utils import gc, log
 
-from . import gfpgan, hypernetwork, realesrgan, stable_diffusion, vae
-
 models = {
-    "stable-diffusion": stable_diffusion,
-    "gfpgan": gfpgan,
-    "realesrgan": realesrgan,
-    "vae": vae,
-    "hypernetwork": hypernetwork,
+    'stable-diffusion': stable_diffusion,
+    'gfpgan': gfpgan,
+    'realesrgan': realesrgan,
+    'vae': vae,
+    'hypernetwork': hypernetwork,
 }
-
 
 def load_model(context: Context, model_type: str, **kwargs):
     if context.model_paths.get(model_type) is None:
@@ -19,17 +19,16 @@ def load_model(context: Context, model_type: str, **kwargs):
     if model_type in context.models:
         unload_model(context, model_type)
 
-    log.info(f"loading {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}")
+    log.info(f'loading {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}')
 
     context.models[model_type] = models[model_type].load_model(context, **kwargs)
 
-    log.info(f"loaded {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}")
+    log.info(f'loaded {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}')
 
     # reload dependent models
-    if model_type == "stable-diffusion":
-        load_model(context, "vae")
-        load_model(context, "hypernetwork")
-
+    if model_type == 'stable-diffusion':
+        load_model(context, 'vae')
+        load_model(context, 'hypernetwork')
 
 def unload_model(context: Context, model_type: str, **kwargs):
     if model_type not in context.models:
@@ -39,4 +38,4 @@ def unload_model(context: Context, model_type: str, **kwargs):
     models[model_type].unload_model(context)
     gc(context)
 
-    log.info(f"unloaded {model_type} model from device: {context.device}")
+    log.info(f'unloaded {model_type} model from device: {context.device}')

--- a/sdkit/models/model_loader/__init__.py
+++ b/sdkit/models/model_loader/__init__.py
@@ -1,8 +1,7 @@
-from . import hypernetwork
-from . import stable_diffusion, gfpgan, realesrgan, vae
-
 from sdkit import Context
 from sdkit.utils import gc, log
+
+from . import gfpgan, hypernetwork, realesrgan, stable_diffusion, vae
 
 models = {
     "stable-diffusion": stable_diffusion,

--- a/sdkit/models/model_loader/__init__.py
+++ b/sdkit/models/model_loader/__init__.py
@@ -19,15 +19,11 @@ def load_model(context: Context, model_type: str, **kwargs):
     if model_type in context.models:
         unload_model(context, model_type)
 
-    log.info(
-        f"loading {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}"
-    )
+    log.info(f"loading {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}")
 
     context.models[model_type] = models[model_type].load_model(context, **kwargs)
 
-    log.info(
-        f"loaded {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}"
-    )
+    log.info(f"loaded {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}")
 
     # reload dependent models
     if model_type == "stable-diffusion":

--- a/sdkit/models/model_loader/__init__.py
+++ b/sdkit/models/model_loader/__init__.py
@@ -5,12 +5,13 @@ from sdkit import Context
 from sdkit.utils import gc, log
 
 models = {
-    'stable-diffusion': stable_diffusion,
-    'gfpgan': gfpgan,
-    'realesrgan': realesrgan,
-    'vae': vae,
-    'hypernetwork': hypernetwork,
+    "stable-diffusion": stable_diffusion,
+    "gfpgan": gfpgan,
+    "realesrgan": realesrgan,
+    "vae": vae,
+    "hypernetwork": hypernetwork,
 }
+
 
 def load_model(context: Context, model_type: str, **kwargs):
     if context.model_paths.get(model_type) is None:
@@ -19,16 +20,17 @@ def load_model(context: Context, model_type: str, **kwargs):
     if model_type in context.models:
         unload_model(context, model_type)
 
-    log.info(f'loading {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}')
+    log.info(f"loading {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}")
 
     context.models[model_type] = models[model_type].load_model(context, **kwargs)
 
-    log.info(f'loaded {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}')
+    log.info(f"loaded {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}")
 
     # reload dependent models
-    if model_type == 'stable-diffusion':
-        load_model(context, 'vae')
-        load_model(context, 'hypernetwork')
+    if model_type == "stable-diffusion":
+        load_model(context, "vae")
+        load_model(context, "hypernetwork")
+
 
 def unload_model(context: Context, model_type: str, **kwargs):
     if model_type not in context.models:
@@ -38,4 +40,4 @@ def unload_model(context: Context, model_type: str, **kwargs):
     models[model_type].unload_model(context)
     gc(context)
 
-    log.info(f'unloaded {model_type} model from device: {context.device}')
+    log.info(f"unloaded {model_type} model from device: {context.device}")

--- a/sdkit/models/model_loader/__init__.py
+++ b/sdkit/models/model_loader/__init__.py
@@ -5,12 +5,13 @@ from sdkit import Context
 from sdkit.utils import gc, log
 
 models = {
-    'stable-diffusion': stable_diffusion,
-    'gfpgan': gfpgan,
-    'realesrgan': realesrgan,
-    'vae': vae,
-    'hypernetwork': hypernetwork,
+    "stable-diffusion": stable_diffusion,
+    "gfpgan": gfpgan,
+    "realesrgan": realesrgan,
+    "vae": vae,
+    "hypernetwork": hypernetwork,
 }
+
 
 def load_model(context: Context, model_type: str, **kwargs):
     if context.model_paths.get(model_type) is None:
@@ -19,16 +20,21 @@ def load_model(context: Context, model_type: str, **kwargs):
     if model_type in context.models:
         unload_model(context, model_type)
 
-    log.info(f'loading {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}')
+    log.info(
+        f"loading {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}"
+    )
 
     context.models[model_type] = models[model_type].load_model(context, **kwargs)
 
-    log.info(f'loaded {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}')
+    log.info(
+        f"loaded {model_type} model from {context.model_paths.get(model_type)} to device: {context.device}"
+    )
 
     # reload dependent models
-    if model_type == 'stable-diffusion':
-        load_model(context, 'vae')
-        load_model(context, 'hypernetwork')
+    if model_type == "stable-diffusion":
+        load_model(context, "vae")
+        load_model(context, "hypernetwork")
+
 
 def unload_model(context: Context, model_type: str, **kwargs):
     if model_type not in context.models:
@@ -38,4 +44,4 @@ def unload_model(context: Context, model_type: str, **kwargs):
     models[model_type].unload_model(context)
     gc(context)
 
-    log.info(f'unloaded {model_type} model from device: {context.device}')
+    log.info(f"unloaded {model_type} model from device: {context.device}")

--- a/sdkit/models/model_loader/gfpgan.py
+++ b/sdkit/models/model_loader/gfpgan.py
@@ -3,14 +3,24 @@ from gfpgan import GFPGANer
 
 from sdkit import Context
 
+
 def load_model(context: Context, **kwargs):
-    model_path = context.model_paths.get('gfpgan')
+    model_path = context.model_paths.get("gfpgan")
 
     # hack for a bug in facexlib: https://github.com/xinntao/facexlib/pull/19/files
     from facexlib.detection import retinaface
+
     retinaface.device = torch.device(context.device)
 
-    return GFPGANer(device=torch.device(context.device), model_path=model_path, upscale=1, arch='clean', channel_multiplier=2, bg_upsampler=None)
+    return GFPGANer(
+        device=torch.device(context.device),
+        model_path=model_path,
+        upscale=1,
+        arch="clean",
+        channel_multiplier=2,
+        bg_upsampler=None,
+    )
+
 
 def unload_model(context: Context, **kwargs):
     pass

--- a/sdkit/models/model_loader/gfpgan.py
+++ b/sdkit/models/model_loader/gfpgan.py
@@ -3,24 +3,14 @@ from gfpgan import GFPGANer
 
 from sdkit import Context
 
-
 def load_model(context: Context, **kwargs):
-    model_path = context.model_paths.get("gfpgan")
+    model_path = context.model_paths.get('gfpgan')
 
     # hack for a bug in facexlib: https://github.com/xinntao/facexlib/pull/19/files
     from facexlib.detection import retinaface
-
     retinaface.device = torch.device(context.device)
 
-    return GFPGANer(
-        device=torch.device(context.device),
-        model_path=model_path,
-        upscale=1,
-        arch="clean",
-        channel_multiplier=2,
-        bg_upsampler=None,
-    )
-
+    return GFPGANer(device=torch.device(context.device), model_path=model_path, upscale=1, arch='clean', channel_multiplier=2, bg_upsampler=None)
 
 def unload_model(context: Context, **kwargs):
     pass

--- a/sdkit/models/model_loader/hypernetwork/__init__.py
+++ b/sdkit/models/model_loader/hypernetwork/__init__.py
@@ -1,7 +1,7 @@
 import traceback
 
 from sdkit import Context
-from sdkit.utils import log, load_tensor_file
+from sdkit.utils import load_tensor_file, log
 
 
 def load_model(context: Context, **kwargs):

--- a/sdkit/models/model_loader/hypernetwork/__init__.py
+++ b/sdkit/models/model_loader/hypernetwork/__init__.py
@@ -1,55 +1,33 @@
 import traceback
 
 from sdkit import Context
-from sdkit.utils import load_tensor_file, log
-
+from sdkit.utils import log, load_tensor_file
 
 def load_model(context: Context, **kwargs):
     from .hypernetwork import HypernetworkModule, override_attention_context_kv
-
-    model_path = context.model_paths.get("hypernetwork")
+    model_path = context.model_paths.get('hypernetwork')
 
     try:
         state_dict = load_tensor_file(model_path)
 
-        layer_structure = state_dict.get("layer_structure", [1, 2, 1])
-        activation_func = state_dict.get("activation_func", None)
-        weight_init = state_dict.get("weight_initialization", "Normal")
-        add_layer_norm = state_dict.get("is_layer_norm", False)
-        use_dropout = state_dict.get("use_dropout", False)
-        activate_output = state_dict.get("activate_output", True)
-        last_layer_dropout = state_dict.get("last_layer_dropout", False)
+        layer_structure = state_dict.get('layer_structure', [1, 2, 1])
+        activation_func = state_dict.get('activation_func', None)
+        weight_init = state_dict.get('weight_initialization', 'Normal')
+        add_layer_norm = state_dict.get('is_layer_norm', False)
+        use_dropout = state_dict.get('use_dropout', False)
+        activate_output = state_dict.get('activate_output', True)
+        last_layer_dropout = state_dict.get('last_layer_dropout', False)
 
-        layers = {"hypernetwork_strength": 0}
+        layers = {'hypernetwork_strength': 0}
         for size, sd in state_dict.items():
             if type(size) == int:
                 layers[size] = (
-                    HypernetworkModule(
-                        size,
-                        sd[0],
-                        layer_structure,
-                        activation_func,
-                        weight_init,
-                        add_layer_norm,
-                        use_dropout,
-                        activate_output,
-                        last_layer_dropout=last_layer_dropout,
-                        model=layers,
-                        device=context.device,
-                    ),
-                    HypernetworkModule(
-                        size,
-                        sd[1],
-                        layer_structure,
-                        activation_func,
-                        weight_init,
-                        add_layer_norm,
-                        use_dropout,
-                        activate_output,
-                        last_layer_dropout=last_layer_dropout,
-                        model=layers,
-                        device=context.device,
-                    ),
+                    HypernetworkModule(size, sd[0], layer_structure, activation_func, weight_init, add_layer_norm,
+                                    use_dropout, activate_output, last_layer_dropout=last_layer_dropout,
+                                    model=layers, device=context.device),
+                    HypernetworkModule(size, sd[1], layer_structure, activation_func, weight_init, add_layer_norm,
+                                    use_dropout, activate_output, last_layer_dropout=last_layer_dropout,
+                                    model=layers, device=context.device),
                 )
 
         override_attention_context_kv(layers)
@@ -57,10 +35,8 @@ def load_model(context: Context, **kwargs):
         return layers
     except:
         log.error(traceback.format_exc())
-        log.error(f"Could not load hypernetwork: {model_path}")
-
+        log.error(f'Could not load hypernetwork: {model_path}')
 
 def unload_model(context: Context, **kwargs):
     from .hypernetwork import override_attention_context_kv
-
     override_attention_context_kv(None)

--- a/sdkit/models/model_loader/hypernetwork/__init__.py
+++ b/sdkit/models/model_loader/hypernetwork/__init__.py
@@ -3,31 +3,53 @@ import traceback
 from sdkit import Context
 from sdkit.utils import log, load_tensor_file
 
+
 def load_model(context: Context, **kwargs):
     from .hypernetwork import HypernetworkModule, override_attention_context_kv
-    model_path = context.model_paths.get('hypernetwork')
+
+    model_path = context.model_paths.get("hypernetwork")
 
     try:
         state_dict = load_tensor_file(model_path)
 
-        layer_structure = state_dict.get('layer_structure', [1, 2, 1])
-        activation_func = state_dict.get('activation_func', None)
-        weight_init = state_dict.get('weight_initialization', 'Normal')
-        add_layer_norm = state_dict.get('is_layer_norm', False)
-        use_dropout = state_dict.get('use_dropout', False)
-        activate_output = state_dict.get('activate_output', True)
-        last_layer_dropout = state_dict.get('last_layer_dropout', False)
+        layer_structure = state_dict.get("layer_structure", [1, 2, 1])
+        activation_func = state_dict.get("activation_func", None)
+        weight_init = state_dict.get("weight_initialization", "Normal")
+        add_layer_norm = state_dict.get("is_layer_norm", False)
+        use_dropout = state_dict.get("use_dropout", False)
+        activate_output = state_dict.get("activate_output", True)
+        last_layer_dropout = state_dict.get("last_layer_dropout", False)
 
-        layers = {'hypernetwork_strength': 0}
+        layers = {"hypernetwork_strength": 0}
         for size, sd in state_dict.items():
             if type(size) == int:
                 layers[size] = (
-                    HypernetworkModule(size, sd[0], layer_structure, activation_func, weight_init, add_layer_norm,
-                                    use_dropout, activate_output, last_layer_dropout=last_layer_dropout,
-                                    model=layers, device=context.device),
-                    HypernetworkModule(size, sd[1], layer_structure, activation_func, weight_init, add_layer_norm,
-                                    use_dropout, activate_output, last_layer_dropout=last_layer_dropout,
-                                    model=layers, device=context.device),
+                    HypernetworkModule(
+                        size,
+                        sd[0],
+                        layer_structure,
+                        activation_func,
+                        weight_init,
+                        add_layer_norm,
+                        use_dropout,
+                        activate_output,
+                        last_layer_dropout=last_layer_dropout,
+                        model=layers,
+                        device=context.device,
+                    ),
+                    HypernetworkModule(
+                        size,
+                        sd[1],
+                        layer_structure,
+                        activation_func,
+                        weight_init,
+                        add_layer_norm,
+                        use_dropout,
+                        activate_output,
+                        last_layer_dropout=last_layer_dropout,
+                        model=layers,
+                        device=context.device,
+                    ),
                 )
 
         override_attention_context_kv(layers)
@@ -35,8 +57,10 @@ def load_model(context: Context, **kwargs):
         return layers
     except:
         log.error(traceback.format_exc())
-        log.error(f'Could not load hypernetwork: {model_path}')
+        log.error(f"Could not load hypernetwork: {model_path}")
+
 
 def unload_model(context: Context, **kwargs):
     from .hypernetwork import override_attention_context_kv
+
     override_attention_context_kv(None)

--- a/sdkit/models/model_loader/hypernetwork/hypernetwork.py
+++ b/sdkit/models/model_loader/hypernetwork/hypernetwork.py
@@ -1,11 +1,8 @@
 # Modified version, originally contributed by c0bra5 - https://github.com/cmdr2/stable-diffusion-ui/pull/619
-# which was a cut down version of
-# https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/c9a2cfdf2a53d37c2de1908423e4f548088667ef/modules/hypernetworks/hypernetwork.py
+# which was a cut down version of https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/c9a2cfdf2a53d37c2de1908423e4f548088667ef/modules/hypernetworks/hypernetwork.py
 
 import inspect
-
 import torch
-
 
 class HypernetworkModule(torch.nn.Module):
     multiplier = 0.5
@@ -18,28 +15,10 @@ class HypernetworkModule(torch.nn.Module):
         "tanh": torch.nn.Tanh,
         "sigmoid": torch.nn.Sigmoid,
     }
-    activation_dict.update(
-        {
-            cls_name.lower(): cls_obj
-            for cls_name, cls_obj in inspect.getmembers(torch.nn.modules.activation)
-            if inspect.isclass(cls_obj) and cls_obj.__module__ == "torch.nn.modules.activation"
-        }
-    )
+    activation_dict.update({cls_name.lower(): cls_obj for cls_name, cls_obj in inspect.getmembers(torch.nn.modules.activation) if inspect.isclass(cls_obj) and cls_obj.__module__ == 'torch.nn.modules.activation'})
 
-    def __init__(
-        self,
-        dim,
-        state_dict=None,
-        layer_structure=None,
-        activation_func=None,
-        weight_init="Normal",
-        add_layer_norm=False,
-        use_dropout=False,
-        activate_output=False,
-        last_layer_dropout=False,
-        model=None,
-        device="cuda",
-    ):
+    def __init__(self, dim, state_dict=None, layer_structure=None, activation_func=None, weight_init='Normal',
+                 add_layer_norm=False, use_dropout=False, activate_output=False, last_layer_dropout=False, model=None, device='cuda'):
         super().__init__()
 
         self.model = model
@@ -50,24 +29,21 @@ class HypernetworkModule(torch.nn.Module):
 
         linears = []
         for i in range(len(layer_structure) - 1):
+
             # Add a fully-connected layer
-            linears.append(torch.nn.Linear(int(dim * layer_structure[i]), int(dim * layer_structure[i + 1])))
+            linears.append(torch.nn.Linear(int(dim * layer_structure[i]), int(dim * layer_structure[i+1])))
 
             # Add an activation func except last layer
-            if (
-                activation_func == "linear"
-                or activation_func is None
-                or (i >= len(layer_structure) - 2 and not activate_output)
-            ):
+            if activation_func == "linear" or activation_func is None or (i >= len(layer_structure) - 2 and not activate_output):
                 pass
             elif activation_func in self.activation_dict:
                 linears.append(self.activation_dict[activation_func]())
             else:
-                raise RuntimeError(f"hypernetwork uses an unsupported activation function: {activation_func}")
+                raise RuntimeError(f'hypernetwork uses an unsupported activation function: {activation_func}')
 
             # Add layer normalization
             if add_layer_norm:
-                linears.append(torch.nn.LayerNorm(int(dim * layer_structure[i + 1])))
+                linears.append(torch.nn.LayerNorm(int(dim * layer_structure[i+1])))
 
             # Add dropout except last layer
             if use_dropout and (i < len(layer_structure) - 3 or last_layer_dropout and i < len(layer_structure) - 2):
@@ -82,10 +58,10 @@ class HypernetworkModule(torch.nn.Module):
 
     def fix_old_state_dict(self, state_dict):
         changes = {
-            "linear1.bias": "linear.0.bias",
-            "linear1.weight": "linear.0.weight",
-            "linear2.bias": "linear.1.bias",
-            "linear2.weight": "linear.1.weight",
+            'linear1.bias': 'linear.0.bias',
+            'linear1.weight': 'linear.0.weight',
+            'linear2.bias': 'linear.1.bias',
+            'linear2.weight': 'linear.1.weight',
         }
 
         for fr, to in changes.items():
@@ -97,8 +73,7 @@ class HypernetworkModule(torch.nn.Module):
             state_dict[to] = x
 
     def forward(self, x: torch.Tensor):
-        return x + self.linear(x) * self.model["hypernetwork_strength"]
-
+        return x + self.linear(x) * self.model['hypernetwork_strength']
 
 def apply_hypernetwork(hypernetwork, attention_context, layer=None):
     hypernetwork_layers = hypernetwork.get(attention_context.shape[2], None)
@@ -114,10 +89,8 @@ def apply_hypernetwork(hypernetwork, attention_context, layer=None):
     attention_context_v = hypernetwork_layers[1](attention_context)
     return attention_context_k, attention_context_v
 
-
 def override_attention_context_kv(hypernetwork_model):
     import sdkit.models.model_loader.stable_diffusion.optimizations as sd_model_optimizer
-
     def get_context_kv(attention_context):
         if hypernetwork_model is None:
             return attention_context, attention_context

--- a/sdkit/models/model_loader/hypernetwork/hypernetwork.py
+++ b/sdkit/models/model_loader/hypernetwork/hypernetwork.py
@@ -2,6 +2,7 @@
 # which was a cut down version of https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/c9a2cfdf2a53d37c2de1908423e4f548088667ef/modules/hypernetworks/hypernetwork.py
 
 import inspect
+
 import torch
 
 

--- a/sdkit/models/model_loader/hypernetwork/hypernetwork.py
+++ b/sdkit/models/model_loader/hypernetwork/hypernetwork.py
@@ -4,6 +4,7 @@
 import inspect
 import torch
 
+
 class HypernetworkModule(torch.nn.Module):
     multiplier = 0.5
     activation_dict = {
@@ -15,10 +16,28 @@ class HypernetworkModule(torch.nn.Module):
         "tanh": torch.nn.Tanh,
         "sigmoid": torch.nn.Sigmoid,
     }
-    activation_dict.update({cls_name.lower(): cls_obj for cls_name, cls_obj in inspect.getmembers(torch.nn.modules.activation) if inspect.isclass(cls_obj) and cls_obj.__module__ == 'torch.nn.modules.activation'})
+    activation_dict.update(
+        {
+            cls_name.lower(): cls_obj
+            for cls_name, cls_obj in inspect.getmembers(torch.nn.modules.activation)
+            if inspect.isclass(cls_obj) and cls_obj.__module__ == "torch.nn.modules.activation"
+        }
+    )
 
-    def __init__(self, dim, state_dict=None, layer_structure=None, activation_func=None, weight_init='Normal',
-                 add_layer_norm=False, use_dropout=False, activate_output=False, last_layer_dropout=False, model=None, device='cuda'):
+    def __init__(
+        self,
+        dim,
+        state_dict=None,
+        layer_structure=None,
+        activation_func=None,
+        weight_init="Normal",
+        add_layer_norm=False,
+        use_dropout=False,
+        activate_output=False,
+        last_layer_dropout=False,
+        model=None,
+        device="cuda",
+    ):
         super().__init__()
 
         self.model = model
@@ -29,21 +48,24 @@ class HypernetworkModule(torch.nn.Module):
 
         linears = []
         for i in range(len(layer_structure) - 1):
-
             # Add a fully-connected layer
-            linears.append(torch.nn.Linear(int(dim * layer_structure[i]), int(dim * layer_structure[i+1])))
+            linears.append(torch.nn.Linear(int(dim * layer_structure[i]), int(dim * layer_structure[i + 1])))
 
             # Add an activation func except last layer
-            if activation_func == "linear" or activation_func is None or (i >= len(layer_structure) - 2 and not activate_output):
+            if (
+                activation_func == "linear"
+                or activation_func is None
+                or (i >= len(layer_structure) - 2 and not activate_output)
+            ):
                 pass
             elif activation_func in self.activation_dict:
                 linears.append(self.activation_dict[activation_func]())
             else:
-                raise RuntimeError(f'hypernetwork uses an unsupported activation function: {activation_func}')
+                raise RuntimeError(f"hypernetwork uses an unsupported activation function: {activation_func}")
 
             # Add layer normalization
             if add_layer_norm:
-                linears.append(torch.nn.LayerNorm(int(dim * layer_structure[i+1])))
+                linears.append(torch.nn.LayerNorm(int(dim * layer_structure[i + 1])))
 
             # Add dropout except last layer
             if use_dropout and (i < len(layer_structure) - 3 or last_layer_dropout and i < len(layer_structure) - 2):
@@ -58,10 +80,10 @@ class HypernetworkModule(torch.nn.Module):
 
     def fix_old_state_dict(self, state_dict):
         changes = {
-            'linear1.bias': 'linear.0.bias',
-            'linear1.weight': 'linear.0.weight',
-            'linear2.bias': 'linear.1.bias',
-            'linear2.weight': 'linear.1.weight',
+            "linear1.bias": "linear.0.bias",
+            "linear1.weight": "linear.0.weight",
+            "linear2.bias": "linear.1.bias",
+            "linear2.weight": "linear.1.weight",
         }
 
         for fr, to in changes.items():
@@ -73,7 +95,8 @@ class HypernetworkModule(torch.nn.Module):
             state_dict[to] = x
 
     def forward(self, x: torch.Tensor):
-        return x + self.linear(x) * self.model['hypernetwork_strength']
+        return x + self.linear(x) * self.model["hypernetwork_strength"]
+
 
 def apply_hypernetwork(hypernetwork, attention_context, layer=None):
     hypernetwork_layers = hypernetwork.get(attention_context.shape[2], None)
@@ -89,8 +112,10 @@ def apply_hypernetwork(hypernetwork, attention_context, layer=None):
     attention_context_v = hypernetwork_layers[1](attention_context)
     return attention_context_k, attention_context_v
 
+
 def override_attention_context_kv(hypernetwork_model):
     import sdkit.models.model_loader.stable_diffusion.optimizations as sd_model_optimizer
+
     def get_context_kv(attention_context):
         if hypernetwork_model is None:
             return attention_context, attention_context

--- a/sdkit/models/model_loader/hypernetwork/hypernetwork.py
+++ b/sdkit/models/model_loader/hypernetwork/hypernetwork.py
@@ -4,6 +4,7 @@
 import inspect
 import torch
 
+
 class HypernetworkModule(torch.nn.Module):
     multiplier = 0.5
     activation_dict = {
@@ -15,10 +16,29 @@ class HypernetworkModule(torch.nn.Module):
         "tanh": torch.nn.Tanh,
         "sigmoid": torch.nn.Sigmoid,
     }
-    activation_dict.update({cls_name.lower(): cls_obj for cls_name, cls_obj in inspect.getmembers(torch.nn.modules.activation) if inspect.isclass(cls_obj) and cls_obj.__module__ == 'torch.nn.modules.activation'})
+    activation_dict.update(
+        {
+            cls_name.lower(): cls_obj
+            for cls_name, cls_obj in inspect.getmembers(torch.nn.modules.activation)
+            if inspect.isclass(cls_obj)
+            and cls_obj.__module__ == "torch.nn.modules.activation"
+        }
+    )
 
-    def __init__(self, dim, state_dict=None, layer_structure=None, activation_func=None, weight_init='Normal',
-                 add_layer_norm=False, use_dropout=False, activate_output=False, last_layer_dropout=False, model=None, device='cuda'):
+    def __init__(
+        self,
+        dim,
+        state_dict=None,
+        layer_structure=None,
+        activation_func=None,
+        weight_init="Normal",
+        add_layer_norm=False,
+        use_dropout=False,
+        activate_output=False,
+        last_layer_dropout=False,
+        model=None,
+        device="cuda",
+    ):
         super().__init__()
 
         self.model = model
@@ -29,24 +49,37 @@ class HypernetworkModule(torch.nn.Module):
 
         linears = []
         for i in range(len(layer_structure) - 1):
-
             # Add a fully-connected layer
-            linears.append(torch.nn.Linear(int(dim * layer_structure[i]), int(dim * layer_structure[i+1])))
+            linears.append(
+                torch.nn.Linear(
+                    int(dim * layer_structure[i]), int(dim * layer_structure[i + 1])
+                )
+            )
 
             # Add an activation func except last layer
-            if activation_func == "linear" or activation_func is None or (i >= len(layer_structure) - 2 and not activate_output):
+            if (
+                activation_func == "linear"
+                or activation_func is None
+                or (i >= len(layer_structure) - 2 and not activate_output)
+            ):
                 pass
             elif activation_func in self.activation_dict:
                 linears.append(self.activation_dict[activation_func]())
             else:
-                raise RuntimeError(f'hypernetwork uses an unsupported activation function: {activation_func}')
+                raise RuntimeError(
+                    f"hypernetwork uses an unsupported activation function: {activation_func}"
+                )
 
             # Add layer normalization
             if add_layer_norm:
-                linears.append(torch.nn.LayerNorm(int(dim * layer_structure[i+1])))
+                linears.append(torch.nn.LayerNorm(int(dim * layer_structure[i + 1])))
 
             # Add dropout except last layer
-            if use_dropout and (i < len(layer_structure) - 3 or last_layer_dropout and i < len(layer_structure) - 2):
+            if use_dropout and (
+                i < len(layer_structure) - 3
+                or last_layer_dropout
+                and i < len(layer_structure) - 2
+            ):
                 linears.append(torch.nn.Dropout(p=0.3))
 
         self.linear = torch.nn.Sequential(*linears)
@@ -58,10 +91,10 @@ class HypernetworkModule(torch.nn.Module):
 
     def fix_old_state_dict(self, state_dict):
         changes = {
-            'linear1.bias': 'linear.0.bias',
-            'linear1.weight': 'linear.0.weight',
-            'linear2.bias': 'linear.1.bias',
-            'linear2.weight': 'linear.1.weight',
+            "linear1.bias": "linear.0.bias",
+            "linear1.weight": "linear.0.weight",
+            "linear2.bias": "linear.1.bias",
+            "linear2.weight": "linear.1.weight",
         }
 
         for fr, to in changes.items():
@@ -73,7 +106,8 @@ class HypernetworkModule(torch.nn.Module):
             state_dict[to] = x
 
     def forward(self, x: torch.Tensor):
-        return x + self.linear(x) * self.model['hypernetwork_strength']
+        return x + self.linear(x) * self.model["hypernetwork_strength"]
+
 
 def apply_hypernetwork(hypernetwork, attention_context, layer=None):
     hypernetwork_layers = hypernetwork.get(attention_context.shape[2], None)
@@ -89,8 +123,10 @@ def apply_hypernetwork(hypernetwork, attention_context, layer=None):
     attention_context_v = hypernetwork_layers[1](attention_context)
     return attention_context_k, attention_context_v
 
+
 def override_attention_context_kv(hypernetwork_model):
     import sdkit.models.model_loader.stable_diffusion.optimizations as sd_model_optimizer
+
     def get_context_kv(attention_context):
         if hypernetwork_model is None:
             return attention_context, attention_context

--- a/sdkit/models/model_loader/hypernetwork/hypernetwork.py
+++ b/sdkit/models/model_loader/hypernetwork/hypernetwork.py
@@ -1,5 +1,6 @@
 # Modified version, originally contributed by c0bra5 - https://github.com/cmdr2/stable-diffusion-ui/pull/619
-# which was a cut down version of https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/c9a2cfdf2a53d37c2de1908423e4f548088667ef/modules/hypernetworks/hypernetwork.py
+# which was a cut down version of
+# https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/c9a2cfdf2a53d37c2de1908423e4f548088667ef/modules/hypernetworks/hypernetwork.py
 
 import inspect
 
@@ -21,8 +22,7 @@ class HypernetworkModule(torch.nn.Module):
         {
             cls_name.lower(): cls_obj
             for cls_name, cls_obj in inspect.getmembers(torch.nn.modules.activation)
-            if inspect.isclass(cls_obj)
-            and cls_obj.__module__ == "torch.nn.modules.activation"
+            if inspect.isclass(cls_obj) and cls_obj.__module__ == "torch.nn.modules.activation"
         }
     )
 
@@ -51,11 +51,7 @@ class HypernetworkModule(torch.nn.Module):
         linears = []
         for i in range(len(layer_structure) - 1):
             # Add a fully-connected layer
-            linears.append(
-                torch.nn.Linear(
-                    int(dim * layer_structure[i]), int(dim * layer_structure[i + 1])
-                )
-            )
+            linears.append(torch.nn.Linear(int(dim * layer_structure[i]), int(dim * layer_structure[i + 1])))
 
             # Add an activation func except last layer
             if (
@@ -67,20 +63,14 @@ class HypernetworkModule(torch.nn.Module):
             elif activation_func in self.activation_dict:
                 linears.append(self.activation_dict[activation_func]())
             else:
-                raise RuntimeError(
-                    f"hypernetwork uses an unsupported activation function: {activation_func}"
-                )
+                raise RuntimeError(f"hypernetwork uses an unsupported activation function: {activation_func}")
 
             # Add layer normalization
             if add_layer_norm:
                 linears.append(torch.nn.LayerNorm(int(dim * layer_structure[i + 1])))
 
             # Add dropout except last layer
-            if use_dropout and (
-                i < len(layer_structure) - 3
-                or last_layer_dropout
-                and i < len(layer_structure) - 2
-            ):
+            if use_dropout and (i < len(layer_structure) - 3 or last_layer_dropout and i < len(layer_structure) - 2):
                 linears.append(torch.nn.Dropout(p=0.3))
 
         self.linear = torch.nn.Sequential(*linears)

--- a/sdkit/models/model_loader/realesrgan.py
+++ b/sdkit/models/model_loader/realesrgan.py
@@ -5,26 +5,32 @@ from realesrgan import RealESRGANer
 
 from sdkit import Context
 
+
 def load_model(context: Context, **kwargs):
-    model_path = context.model_paths.get('realesrgan')
+    model_path = context.model_paths.get("realesrgan")
 
     RealESRGAN_models = {
-        'RealESRGAN_x4plus': RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=23, num_grow_ch=32, scale=4),
-        'RealESRGAN_x4plus_anime_6B': RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=6, num_grow_ch=32, scale=4)
+        "RealESRGAN_x4plus": RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=23, num_grow_ch=32, scale=4),
+        "RealESRGAN_x4plus_anime_6B": RRDBNet(
+            num_in_ch=3, num_out_ch=3, num_feat=64, num_block=6, num_grow_ch=32, scale=4
+        ),
     }
 
     model_to_use = os.path.basename(model_path)
     model_to_use, _ = os.path.splitext(model_to_use)
     model_to_use = RealESRGAN_models[model_to_use]
 
-    half = context.half_precision if context.device != 'cpu' else False
-    model = RealESRGANer(device=torch.device(context.device), scale=4, model_path=model_path, model=model_to_use, pre_pad=0, half=half)
-    if context.device == 'cpu':
-        model.model.to('cpu')
+    half = context.half_precision if context.device != "cpu" else False
+    model = RealESRGANer(
+        device=torch.device(context.device), scale=4, model_path=model_path, model=model_to_use, pre_pad=0, half=half
+    )
+    if context.device == "cpu":
+        model.model.to("cpu")
 
     model.model.name = model_to_use
 
     return model
+
 
 def unload_model(context: Context, **kwargs):
     pass

--- a/sdkit/models/model_loader/realesrgan.py
+++ b/sdkit/models/model_loader/realesrgan.py
@@ -1,5 +1,6 @@
-import torch
 import os
+
+import torch
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from realesrgan import RealESRGANer
 

--- a/sdkit/models/model_loader/realesrgan.py
+++ b/sdkit/models/model_loader/realesrgan.py
@@ -1,49 +1,30 @@
-import os
-
 import torch
+import os
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from realesrgan import RealESRGANer
 
 from sdkit import Context
 
-
 def load_model(context: Context, **kwargs):
-    model_path = context.model_paths.get("realesrgan")
+    model_path = context.model_paths.get('realesrgan')
 
     RealESRGAN_models = {
-        "RealESRGAN_x4plus": RRDBNet(
-            num_in_ch=3,
-            num_out_ch=3,
-            num_feat=64,
-            num_block=23,
-            num_grow_ch=32,
-            scale=4,
-        ),
-        "RealESRGAN_x4plus_anime_6B": RRDBNet(
-            num_in_ch=3, num_out_ch=3, num_feat=64, num_block=6, num_grow_ch=32, scale=4
-        ),
+        'RealESRGAN_x4plus': RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=23, num_grow_ch=32, scale=4),
+        'RealESRGAN_x4plus_anime_6B': RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=6, num_grow_ch=32, scale=4)
     }
 
     model_to_use = os.path.basename(model_path)
     model_to_use, _ = os.path.splitext(model_to_use)
     model_to_use = RealESRGAN_models[model_to_use]
 
-    half = context.half_precision if context.device != "cpu" else False
-    model = RealESRGANer(
-        device=torch.device(context.device),
-        scale=4,
-        model_path=model_path,
-        model=model_to_use,
-        pre_pad=0,
-        half=half,
-    )
-    if context.device == "cpu":
-        model.model.to("cpu")
+    half = context.half_precision if context.device != 'cpu' else False
+    model = RealESRGANer(device=torch.device(context.device), scale=4, model_path=model_path, model=model_to_use, pre_pad=0, half=half)
+    if context.device == 'cpu':
+        model.model.to('cpu')
 
     model.model.name = model_to_use
 
     return model
-
 
 def unload_model(context: Context, **kwargs):
     pass

--- a/sdkit/models/model_loader/realesrgan.py
+++ b/sdkit/models/model_loader/realesrgan.py
@@ -5,26 +5,44 @@ from realesrgan import RealESRGANer
 
 from sdkit import Context
 
+
 def load_model(context: Context, **kwargs):
-    model_path = context.model_paths.get('realesrgan')
+    model_path = context.model_paths.get("realesrgan")
 
     RealESRGAN_models = {
-        'RealESRGAN_x4plus': RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=23, num_grow_ch=32, scale=4),
-        'RealESRGAN_x4plus_anime_6B': RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=6, num_grow_ch=32, scale=4)
+        "RealESRGAN_x4plus": RRDBNet(
+            num_in_ch=3,
+            num_out_ch=3,
+            num_feat=64,
+            num_block=23,
+            num_grow_ch=32,
+            scale=4,
+        ),
+        "RealESRGAN_x4plus_anime_6B": RRDBNet(
+            num_in_ch=3, num_out_ch=3, num_feat=64, num_block=6, num_grow_ch=32, scale=4
+        ),
     }
 
     model_to_use = os.path.basename(model_path)
     model_to_use, _ = os.path.splitext(model_to_use)
     model_to_use = RealESRGAN_models[model_to_use]
 
-    half = context.half_precision if context.device != 'cpu' else False
-    model = RealESRGANer(device=torch.device(context.device), scale=4, model_path=model_path, model=model_to_use, pre_pad=0, half=half)
-    if context.device == 'cpu':
-        model.model.to('cpu')
+    half = context.half_precision if context.device != "cpu" else False
+    model = RealESRGANer(
+        device=torch.device(context.device),
+        scale=4,
+        model_path=model_path,
+        model=model_to_use,
+        pre_pad=0,
+        half=half,
+    )
+    if context.device == "cpu":
+        model.model.to("cpu")
 
     model.model.name = model_to_use
 
     return model
+
 
 def unload_model(context: Context, **kwargs):
     pass

--- a/sdkit/models/model_loader/stable_diffusion/__init__.py
+++ b/sdkit/models/model_loader/stable_diffusion/__init__.py
@@ -12,43 +12,47 @@ from pathlib import Path
 from sdkit import Context
 from sdkit.utils import load_tensor_file, save_tensor_file, hash_file_quick, download_file, log
 
-tr_logging.set_verbosity_error() # suppress unnecessary logging
+tr_logging.set_verbosity_error()  # suppress unnecessary logging
+
 
 def load_model(context: Context, scan_model=True, check_for_config_with_same_name=True, **kwargs):
     from . import optimizations
     from sdkit.models import scan_model as scan_model_fn
 
-    model_path = context.model_paths.get('stable-diffusion')
+    model_path = context.model_paths.get("stable-diffusion")
     config_file_path = get_model_config_file(context, check_for_config_with_same_name)
 
     if scan_model:
         scan_result = scan_model_fn(model_path)
         if scan_result.issues_count > 0 or scan_result.infected_files > 0:
-            raise Exception(f'Model scan failed! Potentially infected model: {model_path}')
+            raise Exception(f"Model scan failed! Potentially infected model: {model_path}")
 
     # load the model file
     sd = load_tensor_file(model_path)
-    sd = sd['state_dict'] if 'state_dict' in sd else sd
+    sd = sd["state_dict"] if "state_dict" in sd else sd
 
     # try to guess the config, if no config file was given
     # check if a key specific to SD 2.0 is missing
-    if config_file_path is None and 'cond_stage_model.model.ln_final.bias' not in sd.keys():
+    if config_file_path is None and "cond_stage_model.model.ln_final.bias" not in sd.keys():
         # try using an SD 1.4 config
         from sdkit.models import get_model_info_from_db
-        sd_v1_4_info = get_model_info_from_db(model_type='stable-diffusion', model_id='1.4')
+
+        sd_v1_4_info = get_model_info_from_db(model_type="stable-diffusion", model_id="1.4")
         config_file_path = resolve_model_config_file_path(sd_v1_4_info, model_path)
 
     # load the config
     if config_file_path is None:
-        raise Exception(f'Unknown model! No config file path specified in context.model_configs for the "stable-diffusion" model!')
+        raise Exception(
+            f'Unknown model! No config file path specified in context.model_configs for the "stable-diffusion" model!'
+        )
 
-    log.info(f'using config: {config_file_path}')
+    log.info(f"using config: {config_file_path}")
     config = OmegaConf.load(config_file_path)
     config.model.params.unet_config.params.use_fp16 = context.half_precision
 
-    extra_config = config.get('extra', {})
-    attn_precision = extra_config.get('attn_precision', 'fp16' if context.half_precision else 'fp32')
-    log.info(f'using attn_precision: {attn_precision}')
+    extra_config = config.get("extra", {})
+    attn_precision = extra_config.get("attn_precision", "fp16" if context.half_precision else "fp32")
+    log.info(f"using attn_precision: {attn_precision}")
 
     # instantiate the model
     model = instantiate_from_config(config.model)
@@ -61,30 +65,36 @@ def load_model(context: Context, scan_model=True, check_for_config_with_same_nam
     del sd
 
     # optimize CrossAttention.forward() for faster performance, and lower VRAM usage
-    ldm.modules.attention.CrossAttention.forward = optimizations.make_attn_forward(context, attn_precision=attn_precision)
+    ldm.modules.attention.CrossAttention.forward = optimizations.make_attn_forward(
+        context, attn_precision=attn_precision
+    )
     ldm.modules.diffusionmodules.model.nonlinearity = silu
 
     # save the model vae into a temp folder (used for restoring the default VAE, if a custom VAE is unloaded)
-    save_tensor_file(model.first_stage_model.state_dict(), os.path.join(tempfile.gettempdir(), 'sd-base-vae.safetensors'))
+    save_tensor_file(
+        model.first_stage_model.state_dict(), os.path.join(tempfile.gettempdir(), "sd-base-vae.safetensors")
+    )
 
     # optimizations.print_model_size_breakdown(model)
 
     return model
 
+
 def unload_model(context: Context, **kwargs):
-    context.module_in_gpu = None # don't keep a dangling reference, prevents gc
+    context.module_in_gpu = None  # don't keep a dangling reference, prevents gc
+
 
 def get_model_config_file(context: Context, check_for_config_with_same_name):
     from sdkit.models import get_model_info_from_db
 
-    if context.model_configs.get('stable-diffusion') is not None:
-        return context.model_configs['stable-diffusion']
+    if context.model_configs.get("stable-diffusion") is not None:
+        return context.model_configs["stable-diffusion"]
 
-    model_path = context.model_paths['stable-diffusion']
+    model_path = context.model_paths["stable-diffusion"]
 
     if check_for_config_with_same_name:
         model_name_path = os.path.splitext(model_path)[0]
-        model_config_path = f'{model_name_path}.yaml'
+        model_config_path = f"{model_name_path}.yaml"
         if os.path.exists(model_config_path):
             return model_config_path
 
@@ -93,14 +103,15 @@ def get_model_config_file(context: Context, check_for_config_with_same_name):
 
     return resolve_model_config_file_path(model_info, model_path)
 
+
 def resolve_model_config_file_path(model_info, model_path):
     if model_info is None:
         return
-    config_url = model_info.get('config_url')
+    config_url = model_info.get("config_url")
     if config_url is None:
         return
 
-    if config_url.startswith('http'):
+    if config_url.startswith("http"):
         config_file_name = os.path.basename(urlparse(config_url).path)
         model_dir_name = os.path.dirname(model_path)
         config_file_path = os.path.join(model_dir_name, config_file_name)
@@ -109,7 +120,8 @@ def resolve_model_config_file_path(model_info, model_path):
             download_file(config_url, config_file_path)
     else:
         from sdkit.models import models_db
+
         models_db_path = Path(models_db.__file__).parent
-        config_file_path = models_db_path/config_url
+        config_file_path = models_db_path / config_url
 
     return config_file_path

--- a/sdkit/models/model_loader/stable_diffusion/__init__.py
+++ b/sdkit/models/model_loader/stable_diffusion/__init__.py
@@ -1,23 +1,31 @@
 import os
-from omegaconf import OmegaConf
-from ldm.util import instantiate_from_config
-from transformers import logging as tr_logging
-from torch.nn.functional import silu
+import tempfile
+from pathlib import Path
+from urllib.parse import urlparse
+
 import ldm.modules.attention
 import ldm.modules.diffusionmodules.model
-import tempfile
-from urllib.parse import urlparse
-from pathlib import Path
+from ldm.util import instantiate_from_config
+from omegaconf import OmegaConf
+from torch.nn.functional import silu
+from transformers import logging as tr_logging
 
 from sdkit import Context
-from sdkit.utils import load_tensor_file, save_tensor_file, hash_file_quick, download_file, log
+from sdkit.utils import (
+    download_file,
+    hash_file_quick,
+    load_tensor_file,
+    log,
+    save_tensor_file,
+)
 
 tr_logging.set_verbosity_error()  # suppress unnecessary logging
 
 
 def load_model(context: Context, scan_model=True, check_for_config_with_same_name=True, **kwargs):
-    from . import optimizations
     from sdkit.models import scan_model as scan_model_fn
+
+    from . import optimizations
 
     model_path = context.model_paths.get("stable-diffusion")
     config_file_path = get_model_config_file(context, check_for_config_with_same_name)

--- a/sdkit/models/model_loader/stable_diffusion/__init__.py
+++ b/sdkit/models/model_loader/stable_diffusion/__init__.py
@@ -51,7 +51,7 @@ def load_model(context: Context, scan_model=True, check_for_config_with_same_nam
     # load the config
     if config_file_path is None:
         raise Exception(
-            f'Unknown model! No config file path specified in context.model_configs for the "stable-diffusion" model!'
+            'Unknown model! No config file path specified in context.model_configs for the "stable-diffusion" model!'
         )
 
     log.info(f"using config: {config_file_path}")

--- a/sdkit/models/model_loader/stable_diffusion/__init__.py
+++ b/sdkit/models/model_loader/stable_diffusion/__init__.py
@@ -22,9 +22,7 @@ from sdkit.utils import (
 tr_logging.set_verbosity_error()  # suppress unnecessary logging
 
 
-def load_model(
-    context: Context, scan_model=True, check_for_config_with_same_name=True, **kwargs
-):
+def load_model(context: Context, scan_model=True, check_for_config_with_same_name=True, **kwargs):
     from sdkit.models import scan_model as scan_model_fn
 
     from . import optimizations
@@ -35,9 +33,7 @@ def load_model(
     if scan_model:
         scan_result = scan_model_fn(model_path)
         if scan_result.issues_count > 0 or scan_result.infected_files > 0:
-            raise Exception(
-                f"Model scan failed! Potentially infected model: {model_path}"
-            )
+            raise Exception(f"Model scan failed! Potentially infected model: {model_path}")
 
     # load the model file
     sd = load_tensor_file(model_path)
@@ -45,22 +41,17 @@ def load_model(
 
     # try to guess the config, if no config file was given
     # check if a key specific to SD 2.0 is missing
-    if (
-        config_file_path is None
-        and "cond_stage_model.model.ln_final.bias" not in sd.keys()
-    ):
+    if config_file_path is None and "cond_stage_model.model.ln_final.bias" not in sd.keys():
         # try using an SD 1.4 config
         from sdkit.models import get_model_info_from_db
 
-        sd_v1_4_info = get_model_info_from_db(
-            model_type="stable-diffusion", model_id="1.4"
-        )
+        sd_v1_4_info = get_model_info_from_db(model_type="stable-diffusion", model_id="1.4")
         config_file_path = resolve_model_config_file_path(sd_v1_4_info, model_path)
 
     # load the config
     if config_file_path is None:
         raise Exception(
-            f'Unknown model! No config file path specified in context.model_configs for the "stable-diffusion" model!'
+            'Unknown model! No config file path specified in context.model_configs for the "stable-diffusion" model!'
         )
 
     log.info(f"using config: {config_file_path}")
@@ -68,9 +59,7 @@ def load_model(
     config.model.params.unet_config.params.use_fp16 = context.half_precision
 
     extra_config = config.get("extra", {})
-    attn_precision = extra_config.get(
-        "attn_precision", "fp16" if context.half_precision else "fp32"
-    )
+    attn_precision = extra_config.get("attn_precision", "fp16" if context.half_precision else "fp32")
     log.info(f"using attn_precision: {attn_precision}")
 
     # instantiate the model

--- a/sdkit/models/model_loader/stable_diffusion/__init__.py
+++ b/sdkit/models/model_loader/stable_diffusion/__init__.py
@@ -1,66 +1,54 @@
 import os
-import tempfile
-from pathlib import Path
-from urllib.parse import urlparse
-
+from omegaconf import OmegaConf
+from ldm.util import instantiate_from_config
+from transformers import logging as tr_logging
+from torch.nn.functional import silu
 import ldm.modules.attention
 import ldm.modules.diffusionmodules.model
-from ldm.util import instantiate_from_config
-from omegaconf import OmegaConf
-from torch.nn.functional import silu
-from transformers import logging as tr_logging
+import tempfile
+from urllib.parse import urlparse
+from pathlib import Path
 
 from sdkit import Context
-from sdkit.utils import (
-    download_file,
-    hash_file_quick,
-    load_tensor_file,
-    log,
-    save_tensor_file,
-)
+from sdkit.utils import load_tensor_file, save_tensor_file, hash_file_quick, download_file, log
 
-tr_logging.set_verbosity_error()  # suppress unnecessary logging
-
+tr_logging.set_verbosity_error() # suppress unnecessary logging
 
 def load_model(context: Context, scan_model=True, check_for_config_with_same_name=True, **kwargs):
+    from . import optimizations
     from sdkit.models import scan_model as scan_model_fn
 
-    from . import optimizations
-
-    model_path = context.model_paths.get("stable-diffusion")
+    model_path = context.model_paths.get('stable-diffusion')
     config_file_path = get_model_config_file(context, check_for_config_with_same_name)
 
     if scan_model:
         scan_result = scan_model_fn(model_path)
         if scan_result.issues_count > 0 or scan_result.infected_files > 0:
-            raise Exception(f"Model scan failed! Potentially infected model: {model_path}")
+            raise Exception(f'Model scan failed! Potentially infected model: {model_path}')
 
     # load the model file
     sd = load_tensor_file(model_path)
-    sd = sd["state_dict"] if "state_dict" in sd else sd
+    sd = sd['state_dict'] if 'state_dict' in sd else sd
 
     # try to guess the config, if no config file was given
     # check if a key specific to SD 2.0 is missing
-    if config_file_path is None and "cond_stage_model.model.ln_final.bias" not in sd.keys():
+    if config_file_path is None and 'cond_stage_model.model.ln_final.bias' not in sd.keys():
         # try using an SD 1.4 config
         from sdkit.models import get_model_info_from_db
-
-        sd_v1_4_info = get_model_info_from_db(model_type="stable-diffusion", model_id="1.4")
+        sd_v1_4_info = get_model_info_from_db(model_type='stable-diffusion', model_id='1.4')
         config_file_path = resolve_model_config_file_path(sd_v1_4_info, model_path)
 
     # load the config
     if config_file_path is None:
-        raise Exception(
-            'Unknown model! No config file path specified in context.model_configs for the "stable-diffusion" model!'
-        )
+        raise Exception(f'Unknown model! No config file path specified in context.model_configs for the "stable-diffusion" model!')
 
-    log.info(f"using config: {config_file_path}")
+    log.info(f'using config: {config_file_path}')
     config = OmegaConf.load(config_file_path)
     config.model.params.unet_config.params.use_fp16 = context.half_precision
 
-    extra_config = config.get("extra", {})
-    attn_precision = extra_config.get("attn_precision", "fp16" if context.half_precision else "fp32")
-    log.info(f"using attn_precision: {attn_precision}")
+    extra_config = config.get('extra', {})
+    attn_precision = extra_config.get('attn_precision', 'fp16' if context.half_precision else 'fp32')
+    log.info(f'using attn_precision: {attn_precision}')
 
     # instantiate the model
     model = instantiate_from_config(config.model)
@@ -73,37 +61,30 @@ def load_model(context: Context, scan_model=True, check_for_config_with_same_nam
     del sd
 
     # optimize CrossAttention.forward() for faster performance, and lower VRAM usage
-    ldm.modules.attention.CrossAttention.forward = optimizations.make_attn_forward(
-        context, attn_precision=attn_precision
-    )
+    ldm.modules.attention.CrossAttention.forward = optimizations.make_attn_forward(context, attn_precision=attn_precision)
     ldm.modules.diffusionmodules.model.nonlinearity = silu
 
     # save the model vae into a temp folder (used for restoring the default VAE, if a custom VAE is unloaded)
-    save_tensor_file(
-        model.first_stage_model.state_dict(),
-        os.path.join(tempfile.gettempdir(), "sd-base-vae.safetensors"),
-    )
+    save_tensor_file(model.first_stage_model.state_dict(), os.path.join(tempfile.gettempdir(), 'sd-base-vae.safetensors'))
 
     # optimizations.print_model_size_breakdown(model)
 
     return model
 
-
 def unload_model(context: Context, **kwargs):
-    context.module_in_gpu = None  # don't keep a dangling reference, prevents gc
-
+    context.module_in_gpu = None # don't keep a dangling reference, prevents gc
 
 def get_model_config_file(context: Context, check_for_config_with_same_name):
     from sdkit.models import get_model_info_from_db
 
-    if context.model_configs.get("stable-diffusion") is not None:
-        return context.model_configs["stable-diffusion"]
+    if context.model_configs.get('stable-diffusion') is not None:
+        return context.model_configs['stable-diffusion']
 
-    model_path = context.model_paths["stable-diffusion"]
+    model_path = context.model_paths['stable-diffusion']
 
     if check_for_config_with_same_name:
         model_name_path = os.path.splitext(model_path)[0]
-        model_config_path = f"{model_name_path}.yaml"
+        model_config_path = f'{model_name_path}.yaml'
         if os.path.exists(model_config_path):
             return model_config_path
 
@@ -112,15 +93,14 @@ def get_model_config_file(context: Context, check_for_config_with_same_name):
 
     return resolve_model_config_file_path(model_info, model_path)
 
-
 def resolve_model_config_file_path(model_info, model_path):
     if model_info is None:
         return
-    config_url = model_info.get("config_url")
+    config_url = model_info.get('config_url')
     if config_url is None:
         return
 
-    if config_url.startswith("http"):
+    if config_url.startswith('http'):
         config_file_name = os.path.basename(urlparse(config_url).path)
         model_dir_name = os.path.dirname(model_path)
         config_file_path = os.path.join(model_dir_name, config_file_name)
@@ -129,8 +109,7 @@ def resolve_model_config_file_path(model_info, model_path):
             download_file(config_url, config_file_path)
     else:
         from sdkit.models import models_db
-
         models_db_path = Path(models_db.__file__).parent
-        config_file_path = models_db_path / config_url
+        config_file_path = models_db_path/config_url
 
     return config_file_path

--- a/sdkit/models/model_loader/stable_diffusion/__init__.py
+++ b/sdkit/models/model_loader/stable_diffusion/__init__.py
@@ -10,45 +10,66 @@ from urllib.parse import urlparse
 from pathlib import Path
 
 from sdkit import Context
-from sdkit.utils import load_tensor_file, save_tensor_file, hash_file_quick, download_file, log
+from sdkit.utils import (
+    load_tensor_file,
+    save_tensor_file,
+    hash_file_quick,
+    download_file,
+    log,
+)
 
-tr_logging.set_verbosity_error() # suppress unnecessary logging
+tr_logging.set_verbosity_error()  # suppress unnecessary logging
 
-def load_model(context: Context, scan_model=True, check_for_config_with_same_name=True, **kwargs):
+
+def load_model(
+    context: Context, scan_model=True, check_for_config_with_same_name=True, **kwargs
+):
     from . import optimizations
     from sdkit.models import scan_model as scan_model_fn
 
-    model_path = context.model_paths.get('stable-diffusion')
+    model_path = context.model_paths.get("stable-diffusion")
     config_file_path = get_model_config_file(context, check_for_config_with_same_name)
 
     if scan_model:
         scan_result = scan_model_fn(model_path)
         if scan_result.issues_count > 0 or scan_result.infected_files > 0:
-            raise Exception(f'Model scan failed! Potentially infected model: {model_path}')
+            raise Exception(
+                f"Model scan failed! Potentially infected model: {model_path}"
+            )
 
     # load the model file
     sd = load_tensor_file(model_path)
-    sd = sd['state_dict'] if 'state_dict' in sd else sd
+    sd = sd["state_dict"] if "state_dict" in sd else sd
 
     # try to guess the config, if no config file was given
     # check if a key specific to SD 2.0 is missing
-    if config_file_path is None and 'cond_stage_model.model.ln_final.bias' not in sd.keys():
+    if (
+        config_file_path is None
+        and "cond_stage_model.model.ln_final.bias" not in sd.keys()
+    ):
         # try using an SD 1.4 config
         from sdkit.models import get_model_info_from_db
-        sd_v1_4_info = get_model_info_from_db(model_type='stable-diffusion', model_id='1.4')
+
+        sd_v1_4_info = get_model_info_from_db(
+            model_type="stable-diffusion", model_id="1.4"
+        )
         config_file_path = resolve_model_config_file_path(sd_v1_4_info, model_path)
 
     # load the config
     if config_file_path is None:
-        raise Exception(f'Unknown model! No config file path specified in context.model_configs for the "stable-diffusion" model!')
+        raise Exception(
+            f'Unknown model! No config file path specified in context.model_configs for the "stable-diffusion" model!'
+        )
 
-    log.info(f'using config: {config_file_path}')
+    log.info(f"using config: {config_file_path}")
     config = OmegaConf.load(config_file_path)
     config.model.params.unet_config.params.use_fp16 = context.half_precision
 
-    extra_config = config.get('extra', {})
-    attn_precision = extra_config.get('attn_precision', 'fp16' if context.half_precision else 'fp32')
-    log.info(f'using attn_precision: {attn_precision}')
+    extra_config = config.get("extra", {})
+    attn_precision = extra_config.get(
+        "attn_precision", "fp16" if context.half_precision else "fp32"
+    )
+    log.info(f"using attn_precision: {attn_precision}")
 
     # instantiate the model
     model = instantiate_from_config(config.model)
@@ -61,30 +82,37 @@ def load_model(context: Context, scan_model=True, check_for_config_with_same_nam
     del sd
 
     # optimize CrossAttention.forward() for faster performance, and lower VRAM usage
-    ldm.modules.attention.CrossAttention.forward = optimizations.make_attn_forward(context, attn_precision=attn_precision)
+    ldm.modules.attention.CrossAttention.forward = optimizations.make_attn_forward(
+        context, attn_precision=attn_precision
+    )
     ldm.modules.diffusionmodules.model.nonlinearity = silu
 
     # save the model vae into a temp folder (used for restoring the default VAE, if a custom VAE is unloaded)
-    save_tensor_file(model.first_stage_model.state_dict(), os.path.join(tempfile.gettempdir(), 'sd-base-vae.safetensors'))
+    save_tensor_file(
+        model.first_stage_model.state_dict(),
+        os.path.join(tempfile.gettempdir(), "sd-base-vae.safetensors"),
+    )
 
     # optimizations.print_model_size_breakdown(model)
 
     return model
 
+
 def unload_model(context: Context, **kwargs):
-    context.module_in_gpu = None # don't keep a dangling reference, prevents gc
+    context.module_in_gpu = None  # don't keep a dangling reference, prevents gc
+
 
 def get_model_config_file(context: Context, check_for_config_with_same_name):
     from sdkit.models import get_model_info_from_db
 
-    if context.model_configs.get('stable-diffusion') is not None:
-        return context.model_configs['stable-diffusion']
+    if context.model_configs.get("stable-diffusion") is not None:
+        return context.model_configs["stable-diffusion"]
 
-    model_path = context.model_paths['stable-diffusion']
+    model_path = context.model_paths["stable-diffusion"]
 
     if check_for_config_with_same_name:
         model_name_path = os.path.splitext(model_path)[0]
-        model_config_path = f'{model_name_path}.yaml'
+        model_config_path = f"{model_name_path}.yaml"
         if os.path.exists(model_config_path):
             return model_config_path
 
@@ -93,14 +121,15 @@ def get_model_config_file(context: Context, check_for_config_with_same_name):
 
     return resolve_model_config_file_path(model_info, model_path)
 
+
 def resolve_model_config_file_path(model_info, model_path):
     if model_info is None:
         return
-    config_url = model_info.get('config_url')
+    config_url = model_info.get("config_url")
     if config_url is None:
         return
 
-    if config_url.startswith('http'):
+    if config_url.startswith("http"):
         config_file_name = os.path.basename(urlparse(config_url).path)
         model_dir_name = os.path.dirname(model_path)
         config_file_path = os.path.join(model_dir_name, config_file_name)
@@ -109,7 +138,8 @@ def resolve_model_config_file_path(model_info, model_path):
             download_file(config_url, config_file_path)
     else:
         from sdkit.models import models_db
+
         models_db_path = Path(models_db.__file__).parent
-        config_file_path = models_db_path/config_url
+        config_file_path = models_db_path / config_url
 
     return config_file_path

--- a/sdkit/models/model_loader/stable_diffusion/__init__.py
+++ b/sdkit/models/model_loader/stable_diffusion/__init__.py
@@ -1,21 +1,22 @@
 import os
-from omegaconf import OmegaConf
-from ldm.util import instantiate_from_config
-from transformers import logging as tr_logging
-from torch.nn.functional import silu
+import tempfile
+from pathlib import Path
+from urllib.parse import urlparse
+
 import ldm.modules.attention
 import ldm.modules.diffusionmodules.model
-import tempfile
-from urllib.parse import urlparse
-from pathlib import Path
+from ldm.util import instantiate_from_config
+from omegaconf import OmegaConf
+from torch.nn.functional import silu
+from transformers import logging as tr_logging
 
 from sdkit import Context
 from sdkit.utils import (
-    load_tensor_file,
-    save_tensor_file,
-    hash_file_quick,
     download_file,
+    hash_file_quick,
+    load_tensor_file,
     log,
+    save_tensor_file,
 )
 
 tr_logging.set_verbosity_error()  # suppress unnecessary logging
@@ -24,8 +25,9 @@ tr_logging.set_verbosity_error()  # suppress unnecessary logging
 def load_model(
     context: Context, scan_model=True, check_for_config_with_same_name=True, **kwargs
 ):
-    from . import optimizations
     from sdkit.models import scan_model as scan_model_fn
+
+    from . import optimizations
 
     model_path = context.model_paths.get("stable-diffusion")
     config_file_path = get_model_config_file(context, check_for_config_with_same_name)

--- a/sdkit/models/model_loader/stable_diffusion/optimizations.py
+++ b/sdkit/models/model_loader/stable_diffusion/optimizations.py
@@ -1,13 +1,11 @@
-import math
-
 import torch
-from einops import rearrange
-from ldm.util import default
 from torch import einsum
+import math
+from ldm.util import default
+from einops import rearrange
 
 from sdkit import Context
 from sdkit.utils import log
-
 
 def send_to_device(context: Context, model):
     """
@@ -17,13 +15,13 @@ def send_to_device(context: Context, model):
     Please see the documentation for `diffusionkit.types.Context.vram_optimizations`
     for a summary of the logic used for VRAM optimizations
     """
-    if len(context.vram_optimizations) == 0 or context.device == "cpu":
-        log.info("No VRAM optimizations being applied")
+    if len(context.vram_optimizations) == 0 or context.device == 'cpu':
+        log.info('No VRAM optimizations being applied')
         model.to(context.device)
         model.cond_stage_model.device = context.device
         return
 
-    log.info(f"VRAM Optimizations: {context.vram_optimizations}")
+    log.info(f'VRAM Optimizations: {context.vram_optimizations}')
 
     # based on the approach at https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/lowvram.py
     # the idea is to keep only one module in the GPU at a time, depending on the desired optimization level
@@ -40,30 +38,21 @@ def send_to_device(context: Context, model):
             return
 
         if context.module_in_gpu is not None:
-            context.module_in_gpu.to("cpu")
-            log.debug(
-                f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to cpu"
-            )
+            context.module_in_gpu.to('cpu')
+            log.debug(f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to cpu")
 
         module.to(context.device)
-        if module == model.cond_stage_model:
-            module.device = context.device
+        if module == model.cond_stage_model: module.device = context.device
         context.module_in_gpu = module
-        log.debug(
-            f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to GPU"
-        )
+        log.debug(f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to GPU")
 
     def wrap_fs_fn(fn, model_to_move):
         def wrap(x):
             move_to_gpu(model_to_move, None)
             return fn(x)
-
         return wrap
 
-    if (
-        "KEEP_FS_AND_CS_IN_CPU" in context.vram_optimizations
-        or "KEEP_ENTIRE_MODEL_IN_CPU" in context.vram_optimizations
-    ):
+    if 'KEEP_FS_AND_CS_IN_CPU' in context.vram_optimizations or 'KEEP_ENTIRE_MODEL_IN_CPU' in context.vram_optimizations:
         # move the FS, CS and the main model to CPU. And send only the overall reference to the correct device
         tmp = model.cond_stage_model, model.first_stage_model, model.model
         model.cond_stage_model, model.first_stage_model, model.model = (None,) * 3
@@ -71,18 +60,16 @@ def send_to_device(context: Context, model):
         model.cond_stage_model, model.first_stage_model, model.model = tmp
 
         # set forward_pre_hook (a feature of torch NN module) to move each module to the GPU only when required
-        model.first_stage_model.log_name = "model.first_stage_model"
+        model.first_stage_model.log_name = 'model.first_stage_model'
         model.first_stage_model.register_forward_pre_hook(move_to_gpu)
         model.first_stage_model.encode = wrap_fs_fn(model.first_stage_model.encode, model.first_stage_model)
         model.first_stage_model.decode = wrap_fs_fn(model.first_stage_model.decode, model.first_stage_model)
 
-        model.cond_stage_model.log_name = "model.cond_stage_model"
+        model.cond_stage_model.log_name = 'model.cond_stage_model'
         model.cond_stage_model.register_forward_pre_hook(move_to_gpu)
         model.cond_stage_model.forward = wrap_fs_fn(model.cond_stage_model.forward, model.cond_stage_model)
 
-    if (
-        "KEEP_ENTIRE_MODEL_IN_CPU" in context.vram_optimizations
-    ):  # apply the same approach, but to the individual blocks in model
+    if 'KEEP_ENTIRE_MODEL_IN_CPU' in context.vram_optimizations: # apply the same approach, but to the individual blocks in model
         d = model.model.diffusion_model
 
         tmp = d.input_blocks, d.middle_block, d.output_blocks, d.time_embed
@@ -90,67 +77,61 @@ def send_to_device(context: Context, model):
         model.model.to(context.device)
         d.input_blocks, d.middle_block, d.output_blocks, d.time_embed = tmp
 
-        d.time_embed.log_name = "model.model.diffusion_model.time_embed"
+        d.time_embed.log_name = 'model.model.diffusion_model.time_embed'
         d.time_embed.register_forward_pre_hook(move_to_gpu)
 
         for i, block in enumerate(d.input_blocks):
-            block.log_name = f"model.model.diffusion_model.input_blocks[{i}]"
+            block.log_name = f'model.model.diffusion_model.input_blocks[{i}]'
             block.register_forward_pre_hook(move_to_gpu)
 
-        d.middle_block.log_name = "model.model.diffusion_model.middle_block"
+        d.middle_block.log_name = 'model.model.diffusion_model.middle_block'
         d.middle_block.register_forward_pre_hook(move_to_gpu)
 
         for i, block in enumerate(d.output_blocks):
-            block.log_name = f"model.model.diffusion_model.output_blocks[{i}]"
+            block.log_name = f'model.model.diffusion_model.output_blocks[{i}]'
             block.register_forward_pre_hook(move_to_gpu)
     else:
         model.model.to(context.device)
 
-    if (
-        "KEEP_ENTIRE_MODEL_IN_CPU" not in context.vram_optimizations
-        and "KEEP_FS_AND_CS_IN_CPU" not in context.vram_optimizations
-    ):
+    if 'KEEP_ENTIRE_MODEL_IN_CPU' not in context.vram_optimizations and 'KEEP_FS_AND_CS_IN_CPU' not in context.vram_optimizations:
         model.to(context.device)
         model.cond_stage_model.device = context.device
 
-
 def get_context_kv(attention_context):
     return attention_context, attention_context
-
 
 # modified version of https://github.com/Doggettx/stable-diffusion/blob/main/ldm/modules/attention.py#L170
 # faster iterations/sec than the default SD implementation, and consumes far less VRAM
 # On a 3060 12 GB (with the sd-v1-4.ckpt model):
 # - without this code, the standard SD sampler runs at 4.5 it/sec, and consumes ~6.6 GB of VRAM
-# - using this code makes the sampler run at 5.6 to 5.9 it/sec,
-#         and consume ~3.6 GB of VRAM on lower-end PCs, and ~4.9 GB on higher-end PCs
-def make_attn_forward(context: Context, attn_precision="fp16"):
+# - using this code makes the sampler run at 5.6 to 5.9 it/sec, and consume ~3.6 GB of VRAM on lower-end PCs, and ~4.9 GB on higher-end PCs
+def make_attn_forward(context: Context, attn_precision='fp16'):
     app_context = context
 
     def get_steps(q, k):
-        if context.device == "cpu" or "SET_ATTENTION_STEP_TO_2" in context.vram_optimizations:
+        if context.device == 'cpu' or 'SET_ATTENTION_STEP_TO_2' in context.vram_optimizations:
             return 2
-        elif "SET_ATTENTION_STEP_TO_4" in context.vram_optimizations:
-            return 4  # use for balanced
-        elif "SET_ATTENTION_STEP_TO_6" in context.vram_optimizations:
+        elif 'SET_ATTENTION_STEP_TO_4' in context.vram_optimizations:
+            return 4 # use for balanced
+        elif 'SET_ATTENTION_STEP_TO_6' in context.vram_optimizations:
             return 6
-        elif "SET_ATTENTION_STEP_TO_8" in context.vram_optimizations:
+        elif 'SET_ATTENTION_STEP_TO_8' in context.vram_optimizations:
             return 8
-        elif "SET_ATTENTION_STEP_TO_16" in context.vram_optimizations:
+        elif 'SET_ATTENTION_STEP_TO_16' in context.vram_optimizations:
             return 16
-        elif "SET_ATTENTION_STEP_TO_24" in context.vram_optimizations:
-            return 24  # use for low
+        elif 'SET_ATTENTION_STEP_TO_24' in context.vram_optimizations:
+            return 24 # use for low
 
         # figure out the available memory
         stats = torch.cuda.memory_stats(q.device)
-        mem_active = stats["active_bytes.all.current"]
-        mem_reserved = stats["reserved_bytes.all.current"]
+        mem_active = stats['active_bytes.all.current']
+        mem_reserved = stats['reserved_bytes.all.current']
         mem_free_cuda, _ = torch.cuda.mem_get_info(torch.cuda.current_device())
         mem_free_torch = mem_reserved - mem_active
         mem_free_total = mem_free_cuda + mem_free_torch
 
         # figure out the required memory
-        gb = 1024**3
+        gb = 1024 ** 3
         tensor_size = q.shape[0] * q.shape[1] * k.shape[1] * q.element_size()
         modifier = 3 if q.element_size() == 2 else 2.5
         mem_required = tensor_size * modifier
@@ -161,11 +142,8 @@ def make_attn_forward(context: Context, attn_precision="fp16"):
 
         if steps > 64:
             max_res = math.floor(math.sqrt(math.sqrt(mem_free_total / 2.5)) / 8) * 64
-            raise RuntimeError(
-                "Not enough memory, use lower resolution (max approx."
-                f" {max_res}x{max_res}). Need: {mem_required / 64 / gb:0.1f} GB free,"
-                f" Have:{mem_free_total / gb:0.1f} GB free"
-            )
+            raise RuntimeError(f'Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). '
+                            f'Need: {mem_required / 64 / gb:0.1f} GB free, Have:{mem_free_total / gb:0.1f} GB free')
 
         return steps
 
@@ -180,10 +158,10 @@ def make_attn_forward(context: Context, attn_precision="fp16"):
         k_in *= self.scale
         del context, x
 
-        q, k, v = map(lambda t: rearrange(t, "b n (h d) -> (b h) n d", h=h), (q_in, k_in, v_in))
+        q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h=h), (q_in, k_in, v_in))
         del q_in, k_in, v_in
 
-        autocast_device = "cpu" if app_context.device == "cpu" else "cuda"  # doesn't accept (or need) 'cuda:N'
+        autocast_device = 'cpu' if app_context.device == 'cpu' else 'cuda' # doesn't accept (or need) 'cuda:N'
 
         r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype)
         steps = get_steps(q, k)
@@ -193,25 +171,24 @@ def make_attn_forward(context: Context, attn_precision="fp16"):
             if attn_precision == "fp32":
                 with torch.autocast(enabled=False, device_type=autocast_device):
                     q, k = q.float(), k.float()
-                    s1 = einsum("b i d, b j d -> b i j", q[:, i:end], k)
+                    s1 = einsum('b i d, b j d -> b i j', q[:, i:end], k)
             else:
-                s1 = einsum("b i d, b j d -> b i j", q[:, i:end], k)
+                s1 = einsum('b i d, b j d -> b i j', q[:, i:end], k)
 
             s2 = s1.softmax(dim=-1, dtype=q.dtype)
             del s1
 
-            r1[:, i:end] = einsum("b i j, b j d -> b i d", s2, v)
+            r1[:, i:end] = einsum('b i j, b j d -> b i d', s2, v)
             del s2
 
         del q, k, v
 
-        r2 = rearrange(r1, "(b h) n d -> b n (h d)", h=h)
+        r2 = rearrange(r1, '(b h) n d -> b n (h d)', h=h)
         del r1
 
         return self.to_out(r2)
 
     return forward
-
 
 def print_model_size_breakdown(model):
     """
@@ -227,31 +204,28 @@ def print_model_size_breakdown(model):
     size_input, size_middle, size_output = 0, 0, 0
     for key, val in model.model.diffusion_model.state_dict().items():
         s = val.element_size() * val.nelement()
-        if "input" in key:
+        if 'input' in key:
             size_input += s
-        elif "middle" in key:
+        elif 'middle' in key:
             size_middle += s
-        elif "output" in key:
+        elif 'output' in key:
             size_output += s
 
-    log.info(
-        f"model.diffusion_model (input, middle, output blocks): {mb(size_input)} Mb,"
-        f" {mb(size_middle)} Mb, {mb(size_output)} Mb"
-    )
-    log.info(f"model.diffusion_model (total): {mb(size_input + size_middle + size_output)} Mb")
+    log.info(f'model.diffusion_model (input, middle, output blocks): {mb(size_input)} Mb, {mb(size_middle)} Mb, {mb(size_output)} Mb')
+    log.info(f'model.diffusion_model (total): {mb(size_input + size_middle + size_output)} Mb')
 
     # modelFS
     sizeFS = 0
     for _, val in model.first_stage_model.state_dict().items():
         sizeFS += val.element_size() * val.nelement()
 
-    log.info(f"model.first_stage_model: {mb(sizeFS)} Mb")
+    log.info(f'model.first_stage_model: {mb(sizeFS)} Mb')
 
     # modelCS
     sizeCS = 0
     for _, val in model.cond_stage_model.state_dict().items():
         sizeCS += val.element_size() * val.nelement()
 
-    log.info(f"model.cond_stage_model: {mb(sizeCS)} Mb")
+    log.info(f'model.cond_stage_model: {mb(sizeCS)} Mb')
 
-    log.info(f"model (TOTAL): {mb(size_input + size_middle + size_output + sizeFS + sizeCS)} Mb")
+    log.info(f'model (TOTAL): {mb(size_input + size_middle + size_output + sizeFS + sizeCS)} Mb')

--- a/sdkit/models/model_loader/stable_diffusion/optimizations.py
+++ b/sdkit/models/model_loader/stable_diffusion/optimizations.py
@@ -7,6 +7,7 @@ from einops import rearrange
 from sdkit import Context
 from sdkit.utils import log
 
+
 def send_to_device(context: Context, model):
     """
     Sends the model to the device, based on the VRAM optimizations set in
@@ -15,13 +16,13 @@ def send_to_device(context: Context, model):
     Please see the documentation for `diffusionkit.types.Context.vram_optimizations`
     for a summary of the logic used for VRAM optimizations
     """
-    if len(context.vram_optimizations) == 0 or context.device == 'cpu':
-        log.info('No VRAM optimizations being applied')
+    if len(context.vram_optimizations) == 0 or context.device == "cpu":
+        log.info("No VRAM optimizations being applied")
         model.to(context.device)
         model.cond_stage_model.device = context.device
         return
 
-    log.info(f'VRAM Optimizations: {context.vram_optimizations}')
+    log.info(f"VRAM Optimizations: {context.vram_optimizations}")
 
     # based on the approach at https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/lowvram.py
     # the idea is to keep only one module in the GPU at a time, depending on the desired optimization level
@@ -38,21 +39,30 @@ def send_to_device(context: Context, model):
             return
 
         if context.module_in_gpu is not None:
-            context.module_in_gpu.to('cpu')
-            log.debug(f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to cpu")
+            context.module_in_gpu.to("cpu")
+            log.debug(
+                f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to cpu"
+            )
 
         module.to(context.device)
-        if module == model.cond_stage_model: module.device = context.device
+        if module == model.cond_stage_model:
+            module.device = context.device
         context.module_in_gpu = module
-        log.debug(f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to GPU")
+        log.debug(
+            f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to GPU"
+        )
 
     def wrap_fs_fn(fn, model_to_move):
         def wrap(x):
             move_to_gpu(model_to_move, None)
             return fn(x)
+
         return wrap
 
-    if 'KEEP_FS_AND_CS_IN_CPU' in context.vram_optimizations or 'KEEP_ENTIRE_MODEL_IN_CPU' in context.vram_optimizations:
+    if (
+        "KEEP_FS_AND_CS_IN_CPU" in context.vram_optimizations
+        or "KEEP_ENTIRE_MODEL_IN_CPU" in context.vram_optimizations
+    ):
         # move the FS, CS and the main model to CPU. And send only the overall reference to the correct device
         tmp = model.cond_stage_model, model.first_stage_model, model.model
         model.cond_stage_model, model.first_stage_model, model.model = (None,) * 3
@@ -60,16 +70,24 @@ def send_to_device(context: Context, model):
         model.cond_stage_model, model.first_stage_model, model.model = tmp
 
         # set forward_pre_hook (a feature of torch NN module) to move each module to the GPU only when required
-        model.first_stage_model.log_name = 'model.first_stage_model'
+        model.first_stage_model.log_name = "model.first_stage_model"
         model.first_stage_model.register_forward_pre_hook(move_to_gpu)
-        model.first_stage_model.encode = wrap_fs_fn(model.first_stage_model.encode, model.first_stage_model)
-        model.first_stage_model.decode = wrap_fs_fn(model.first_stage_model.decode, model.first_stage_model)
+        model.first_stage_model.encode = wrap_fs_fn(
+            model.first_stage_model.encode, model.first_stage_model
+        )
+        model.first_stage_model.decode = wrap_fs_fn(
+            model.first_stage_model.decode, model.first_stage_model
+        )
 
-        model.cond_stage_model.log_name = 'model.cond_stage_model'
+        model.cond_stage_model.log_name = "model.cond_stage_model"
         model.cond_stage_model.register_forward_pre_hook(move_to_gpu)
-        model.cond_stage_model.forward = wrap_fs_fn(model.cond_stage_model.forward, model.cond_stage_model)
+        model.cond_stage_model.forward = wrap_fs_fn(
+            model.cond_stage_model.forward, model.cond_stage_model
+        )
 
-    if 'KEEP_ENTIRE_MODEL_IN_CPU' in context.vram_optimizations: # apply the same approach, but to the individual blocks in model
+    if (
+        "KEEP_ENTIRE_MODEL_IN_CPU" in context.vram_optimizations
+    ):  # apply the same approach, but to the individual blocks in model
         d = model.model.diffusion_model
 
         tmp = d.input_blocks, d.middle_block, d.output_blocks, d.time_embed
@@ -77,61 +95,69 @@ def send_to_device(context: Context, model):
         model.model.to(context.device)
         d.input_blocks, d.middle_block, d.output_blocks, d.time_embed = tmp
 
-        d.time_embed.log_name = 'model.model.diffusion_model.time_embed'
+        d.time_embed.log_name = "model.model.diffusion_model.time_embed"
         d.time_embed.register_forward_pre_hook(move_to_gpu)
 
         for i, block in enumerate(d.input_blocks):
-            block.log_name = f'model.model.diffusion_model.input_blocks[{i}]'
+            block.log_name = f"model.model.diffusion_model.input_blocks[{i}]"
             block.register_forward_pre_hook(move_to_gpu)
 
-        d.middle_block.log_name = 'model.model.diffusion_model.middle_block'
+        d.middle_block.log_name = "model.model.diffusion_model.middle_block"
         d.middle_block.register_forward_pre_hook(move_to_gpu)
 
         for i, block in enumerate(d.output_blocks):
-            block.log_name = f'model.model.diffusion_model.output_blocks[{i}]'
+            block.log_name = f"model.model.diffusion_model.output_blocks[{i}]"
             block.register_forward_pre_hook(move_to_gpu)
     else:
         model.model.to(context.device)
 
-    if 'KEEP_ENTIRE_MODEL_IN_CPU' not in context.vram_optimizations and 'KEEP_FS_AND_CS_IN_CPU' not in context.vram_optimizations:
+    if (
+        "KEEP_ENTIRE_MODEL_IN_CPU" not in context.vram_optimizations
+        and "KEEP_FS_AND_CS_IN_CPU" not in context.vram_optimizations
+    ):
         model.to(context.device)
         model.cond_stage_model.device = context.device
 
+
 def get_context_kv(attention_context):
     return attention_context, attention_context
+
 
 # modified version of https://github.com/Doggettx/stable-diffusion/blob/main/ldm/modules/attention.py#L170
 # faster iterations/sec than the default SD implementation, and consumes far less VRAM
 # On a 3060 12 GB (with the sd-v1-4.ckpt model):
 # - without this code, the standard SD sampler runs at 4.5 it/sec, and consumes ~6.6 GB of VRAM
 # - using this code makes the sampler run at 5.6 to 5.9 it/sec, and consume ~3.6 GB of VRAM on lower-end PCs, and ~4.9 GB on higher-end PCs
-def make_attn_forward(context: Context, attn_precision='fp16'):
+def make_attn_forward(context: Context, attn_precision="fp16"):
     app_context = context
 
     def get_steps(q, k):
-        if context.device == 'cpu' or 'SET_ATTENTION_STEP_TO_2' in context.vram_optimizations:
+        if (
+            context.device == "cpu"
+            or "SET_ATTENTION_STEP_TO_2" in context.vram_optimizations
+        ):
             return 2
-        elif 'SET_ATTENTION_STEP_TO_4' in context.vram_optimizations:
-            return 4 # use for balanced
-        elif 'SET_ATTENTION_STEP_TO_6' in context.vram_optimizations:
+        elif "SET_ATTENTION_STEP_TO_4" in context.vram_optimizations:
+            return 4  # use for balanced
+        elif "SET_ATTENTION_STEP_TO_6" in context.vram_optimizations:
             return 6
-        elif 'SET_ATTENTION_STEP_TO_8' in context.vram_optimizations:
+        elif "SET_ATTENTION_STEP_TO_8" in context.vram_optimizations:
             return 8
-        elif 'SET_ATTENTION_STEP_TO_16' in context.vram_optimizations:
+        elif "SET_ATTENTION_STEP_TO_16" in context.vram_optimizations:
             return 16
-        elif 'SET_ATTENTION_STEP_TO_24' in context.vram_optimizations:
-            return 24 # use for low
+        elif "SET_ATTENTION_STEP_TO_24" in context.vram_optimizations:
+            return 24  # use for low
 
         # figure out the available memory
         stats = torch.cuda.memory_stats(q.device)
-        mem_active = stats['active_bytes.all.current']
-        mem_reserved = stats['reserved_bytes.all.current']
+        mem_active = stats["active_bytes.all.current"]
+        mem_reserved = stats["reserved_bytes.all.current"]
         mem_free_cuda, _ = torch.cuda.mem_get_info(torch.cuda.current_device())
         mem_free_torch = mem_reserved - mem_active
         mem_free_total = mem_free_cuda + mem_free_torch
 
         # figure out the required memory
-        gb = 1024 ** 3
+        gb = 1024**3
         tensor_size = q.shape[0] * q.shape[1] * k.shape[1] * q.element_size()
         modifier = 3 if q.element_size() == 2 else 2.5
         mem_required = tensor_size * modifier
@@ -142,8 +168,10 @@ def make_attn_forward(context: Context, attn_precision='fp16'):
 
         if steps > 64:
             max_res = math.floor(math.sqrt(math.sqrt(mem_free_total / 2.5)) / 8) * 64
-            raise RuntimeError(f'Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). '
-                            f'Need: {mem_required / 64 / gb:0.1f} GB free, Have:{mem_free_total / gb:0.1f} GB free')
+            raise RuntimeError(
+                f"Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). "
+                f"Need: {mem_required / 64 / gb:0.1f} GB free, Have:{mem_free_total / gb:0.1f} GB free"
+            )
 
         return steps
 
@@ -158,12 +186,18 @@ def make_attn_forward(context: Context, attn_precision='fp16'):
         k_in *= self.scale
         del context, x
 
-        q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h=h), (q_in, k_in, v_in))
+        q, k, v = map(
+            lambda t: rearrange(t, "b n (h d) -> (b h) n d", h=h), (q_in, k_in, v_in)
+        )
         del q_in, k_in, v_in
 
-        autocast_device = 'cpu' if app_context.device == 'cpu' else 'cuda' # doesn't accept (or need) 'cuda:N'
+        autocast_device = (
+            "cpu" if app_context.device == "cpu" else "cuda"
+        )  # doesn't accept (or need) 'cuda:N'
 
-        r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype)
+        r1 = torch.zeros(
+            q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype
+        )
         steps = get_steps(q, k)
         slice_size = q.shape[1] // steps if (q.shape[1] % steps) == 0 else q.shape[1]
         for i in range(0, q.shape[1], slice_size):
@@ -171,24 +205,25 @@ def make_attn_forward(context: Context, attn_precision='fp16'):
             if attn_precision == "fp32":
                 with torch.autocast(enabled=False, device_type=autocast_device):
                     q, k = q.float(), k.float()
-                    s1 = einsum('b i d, b j d -> b i j', q[:, i:end], k)
+                    s1 = einsum("b i d, b j d -> b i j", q[:, i:end], k)
             else:
-                s1 = einsum('b i d, b j d -> b i j', q[:, i:end], k)
+                s1 = einsum("b i d, b j d -> b i j", q[:, i:end], k)
 
             s2 = s1.softmax(dim=-1, dtype=q.dtype)
             del s1
 
-            r1[:, i:end] = einsum('b i j, b j d -> b i d', s2, v)
+            r1[:, i:end] = einsum("b i j, b j d -> b i d", s2, v)
             del s2
 
         del q, k, v
 
-        r2 = rearrange(r1, '(b h) n d -> b n (h d)', h=h)
+        r2 = rearrange(r1, "(b h) n d -> b n (h d)", h=h)
         del r1
 
         return self.to_out(r2)
 
     return forward
+
 
 def print_model_size_breakdown(model):
     """
@@ -204,28 +239,34 @@ def print_model_size_breakdown(model):
     size_input, size_middle, size_output = 0, 0, 0
     for key, val in model.model.diffusion_model.state_dict().items():
         s = val.element_size() * val.nelement()
-        if 'input' in key:
+        if "input" in key:
             size_input += s
-        elif 'middle' in key:
+        elif "middle" in key:
             size_middle += s
-        elif 'output' in key:
+        elif "output" in key:
             size_output += s
 
-    log.info(f'model.diffusion_model (input, middle, output blocks): {mb(size_input)} Mb, {mb(size_middle)} Mb, {mb(size_output)} Mb')
-    log.info(f'model.diffusion_model (total): {mb(size_input + size_middle + size_output)} Mb')
+    log.info(
+        f"model.diffusion_model (input, middle, output blocks): {mb(size_input)} Mb, {mb(size_middle)} Mb, {mb(size_output)} Mb"
+    )
+    log.info(
+        f"model.diffusion_model (total): {mb(size_input + size_middle + size_output)} Mb"
+    )
 
     # modelFS
     sizeFS = 0
     for _, val in model.first_stage_model.state_dict().items():
         sizeFS += val.element_size() * val.nelement()
 
-    log.info(f'model.first_stage_model: {mb(sizeFS)} Mb')
+    log.info(f"model.first_stage_model: {mb(sizeFS)} Mb")
 
     # modelCS
     sizeCS = 0
     for _, val in model.cond_stage_model.state_dict().items():
         sizeCS += val.element_size() * val.nelement()
 
-    log.info(f'model.cond_stage_model: {mb(sizeCS)} Mb')
+    log.info(f"model.cond_stage_model: {mb(sizeCS)} Mb")
 
-    log.info(f'model (TOTAL): {mb(size_input + size_middle + size_output + sizeFS + sizeCS)} Mb')
+    log.info(
+        f"model (TOTAL): {mb(size_input + size_middle + size_output + sizeFS + sizeCS)} Mb"
+    )

--- a/sdkit/models/model_loader/stable_diffusion/optimizations.py
+++ b/sdkit/models/model_loader/stable_diffusion/optimizations.py
@@ -1,8 +1,9 @@
-import torch
-from torch import einsum
 import math
-from ldm.util import default
+
+import torch
 from einops import rearrange
+from ldm.util import default
+from torch import einsum
 
 from sdkit import Context
 from sdkit.utils import log

--- a/sdkit/models/model_loader/stable_diffusion/optimizations.py
+++ b/sdkit/models/model_loader/stable_diffusion/optimizations.py
@@ -7,6 +7,7 @@ from einops import rearrange
 from sdkit import Context
 from sdkit.utils import log
 
+
 def send_to_device(context: Context, model):
     """
     Sends the model to the device, based on the VRAM optimizations set in
@@ -15,13 +16,13 @@ def send_to_device(context: Context, model):
     Please see the documentation for `diffusionkit.types.Context.vram_optimizations`
     for a summary of the logic used for VRAM optimizations
     """
-    if len(context.vram_optimizations) == 0 or context.device == 'cpu':
-        log.info('No VRAM optimizations being applied')
+    if len(context.vram_optimizations) == 0 or context.device == "cpu":
+        log.info("No VRAM optimizations being applied")
         model.to(context.device)
         model.cond_stage_model.device = context.device
         return
 
-    log.info(f'VRAM Optimizations: {context.vram_optimizations}')
+    log.info(f"VRAM Optimizations: {context.vram_optimizations}")
 
     # based on the approach at https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/lowvram.py
     # the idea is to keep only one module in the GPU at a time, depending on the desired optimization level
@@ -38,21 +39,30 @@ def send_to_device(context: Context, model):
             return
 
         if context.module_in_gpu is not None:
-            context.module_in_gpu.to('cpu')
-            log.debug(f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to cpu")
+            context.module_in_gpu.to("cpu")
+            log.debug(
+                f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to cpu"
+            )
 
         module.to(context.device)
-        if module == model.cond_stage_model: module.device = context.device
+        if module == model.cond_stage_model:
+            module.device = context.device
         context.module_in_gpu = module
-        log.debug(f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to GPU")
+        log.debug(
+            f"moved {getattr(context.module_in_gpu, 'log_name', context.module_in_gpu.__class__.__name__)} to GPU"
+        )
 
     def wrap_fs_fn(fn, model_to_move):
         def wrap(x):
             move_to_gpu(model_to_move, None)
             return fn(x)
+
         return wrap
 
-    if 'KEEP_FS_AND_CS_IN_CPU' in context.vram_optimizations or 'KEEP_ENTIRE_MODEL_IN_CPU' in context.vram_optimizations:
+    if (
+        "KEEP_FS_AND_CS_IN_CPU" in context.vram_optimizations
+        or "KEEP_ENTIRE_MODEL_IN_CPU" in context.vram_optimizations
+    ):
         # move the FS, CS and the main model to CPU. And send only the overall reference to the correct device
         tmp = model.cond_stage_model, model.first_stage_model, model.model
         model.cond_stage_model, model.first_stage_model, model.model = (None,) * 3
@@ -60,16 +70,18 @@ def send_to_device(context: Context, model):
         model.cond_stage_model, model.first_stage_model, model.model = tmp
 
         # set forward_pre_hook (a feature of torch NN module) to move each module to the GPU only when required
-        model.first_stage_model.log_name = 'model.first_stage_model'
+        model.first_stage_model.log_name = "model.first_stage_model"
         model.first_stage_model.register_forward_pre_hook(move_to_gpu)
         model.first_stage_model.encode = wrap_fs_fn(model.first_stage_model.encode, model.first_stage_model)
         model.first_stage_model.decode = wrap_fs_fn(model.first_stage_model.decode, model.first_stage_model)
 
-        model.cond_stage_model.log_name = 'model.cond_stage_model'
+        model.cond_stage_model.log_name = "model.cond_stage_model"
         model.cond_stage_model.register_forward_pre_hook(move_to_gpu)
         model.cond_stage_model.forward = wrap_fs_fn(model.cond_stage_model.forward, model.cond_stage_model)
 
-    if 'KEEP_ENTIRE_MODEL_IN_CPU' in context.vram_optimizations: # apply the same approach, but to the individual blocks in model
+    if (
+        "KEEP_ENTIRE_MODEL_IN_CPU" in context.vram_optimizations
+    ):  # apply the same approach, but to the individual blocks in model
         d = model.model.diffusion_model
 
         tmp = d.input_blocks, d.middle_block, d.output_blocks, d.time_embed
@@ -77,61 +89,66 @@ def send_to_device(context: Context, model):
         model.model.to(context.device)
         d.input_blocks, d.middle_block, d.output_blocks, d.time_embed = tmp
 
-        d.time_embed.log_name = 'model.model.diffusion_model.time_embed'
+        d.time_embed.log_name = "model.model.diffusion_model.time_embed"
         d.time_embed.register_forward_pre_hook(move_to_gpu)
 
         for i, block in enumerate(d.input_blocks):
-            block.log_name = f'model.model.diffusion_model.input_blocks[{i}]'
+            block.log_name = f"model.model.diffusion_model.input_blocks[{i}]"
             block.register_forward_pre_hook(move_to_gpu)
 
-        d.middle_block.log_name = 'model.model.diffusion_model.middle_block'
+        d.middle_block.log_name = "model.model.diffusion_model.middle_block"
         d.middle_block.register_forward_pre_hook(move_to_gpu)
 
         for i, block in enumerate(d.output_blocks):
-            block.log_name = f'model.model.diffusion_model.output_blocks[{i}]'
+            block.log_name = f"model.model.diffusion_model.output_blocks[{i}]"
             block.register_forward_pre_hook(move_to_gpu)
     else:
         model.model.to(context.device)
 
-    if 'KEEP_ENTIRE_MODEL_IN_CPU' not in context.vram_optimizations and 'KEEP_FS_AND_CS_IN_CPU' not in context.vram_optimizations:
+    if (
+        "KEEP_ENTIRE_MODEL_IN_CPU" not in context.vram_optimizations
+        and "KEEP_FS_AND_CS_IN_CPU" not in context.vram_optimizations
+    ):
         model.to(context.device)
         model.cond_stage_model.device = context.device
 
+
 def get_context_kv(attention_context):
     return attention_context, attention_context
+
 
 # modified version of https://github.com/Doggettx/stable-diffusion/blob/main/ldm/modules/attention.py#L170
 # faster iterations/sec than the default SD implementation, and consumes far less VRAM
 # On a 3060 12 GB (with the sd-v1-4.ckpt model):
 # - without this code, the standard SD sampler runs at 4.5 it/sec, and consumes ~6.6 GB of VRAM
 # - using this code makes the sampler run at 5.6 to 5.9 it/sec, and consume ~3.6 GB of VRAM on lower-end PCs, and ~4.9 GB on higher-end PCs
-def make_attn_forward(context: Context, attn_precision='fp16'):
+def make_attn_forward(context: Context, attn_precision="fp16"):
     app_context = context
 
     def get_steps(q, k):
-        if context.device == 'cpu' or 'SET_ATTENTION_STEP_TO_2' in context.vram_optimizations:
+        if context.device == "cpu" or "SET_ATTENTION_STEP_TO_2" in context.vram_optimizations:
             return 2
-        elif 'SET_ATTENTION_STEP_TO_4' in context.vram_optimizations:
-            return 4 # use for balanced
-        elif 'SET_ATTENTION_STEP_TO_6' in context.vram_optimizations:
+        elif "SET_ATTENTION_STEP_TO_4" in context.vram_optimizations:
+            return 4  # use for balanced
+        elif "SET_ATTENTION_STEP_TO_6" in context.vram_optimizations:
             return 6
-        elif 'SET_ATTENTION_STEP_TO_8' in context.vram_optimizations:
+        elif "SET_ATTENTION_STEP_TO_8" in context.vram_optimizations:
             return 8
-        elif 'SET_ATTENTION_STEP_TO_16' in context.vram_optimizations:
+        elif "SET_ATTENTION_STEP_TO_16" in context.vram_optimizations:
             return 16
-        elif 'SET_ATTENTION_STEP_TO_24' in context.vram_optimizations:
-            return 24 # use for low
+        elif "SET_ATTENTION_STEP_TO_24" in context.vram_optimizations:
+            return 24  # use for low
 
         # figure out the available memory
         stats = torch.cuda.memory_stats(q.device)
-        mem_active = stats['active_bytes.all.current']
-        mem_reserved = stats['reserved_bytes.all.current']
+        mem_active = stats["active_bytes.all.current"]
+        mem_reserved = stats["reserved_bytes.all.current"]
         mem_free_cuda, _ = torch.cuda.mem_get_info(torch.cuda.current_device())
         mem_free_torch = mem_reserved - mem_active
         mem_free_total = mem_free_cuda + mem_free_torch
 
         # figure out the required memory
-        gb = 1024 ** 3
+        gb = 1024**3
         tensor_size = q.shape[0] * q.shape[1] * k.shape[1] * q.element_size()
         modifier = 3 if q.element_size() == 2 else 2.5
         mem_required = tensor_size * modifier
@@ -142,8 +159,10 @@ def make_attn_forward(context: Context, attn_precision='fp16'):
 
         if steps > 64:
             max_res = math.floor(math.sqrt(math.sqrt(mem_free_total / 2.5)) / 8) * 64
-            raise RuntimeError(f'Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). '
-                            f'Need: {mem_required / 64 / gb:0.1f} GB free, Have:{mem_free_total / gb:0.1f} GB free')
+            raise RuntimeError(
+                f"Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). "
+                f"Need: {mem_required / 64 / gb:0.1f} GB free, Have:{mem_free_total / gb:0.1f} GB free"
+            )
 
         return steps
 
@@ -158,10 +177,10 @@ def make_attn_forward(context: Context, attn_precision='fp16'):
         k_in *= self.scale
         del context, x
 
-        q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h=h), (q_in, k_in, v_in))
+        q, k, v = map(lambda t: rearrange(t, "b n (h d) -> (b h) n d", h=h), (q_in, k_in, v_in))
         del q_in, k_in, v_in
 
-        autocast_device = 'cpu' if app_context.device == 'cpu' else 'cuda' # doesn't accept (or need) 'cuda:N'
+        autocast_device = "cpu" if app_context.device == "cpu" else "cuda"  # doesn't accept (or need) 'cuda:N'
 
         r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype)
         steps = get_steps(q, k)
@@ -171,24 +190,25 @@ def make_attn_forward(context: Context, attn_precision='fp16'):
             if attn_precision == "fp32":
                 with torch.autocast(enabled=False, device_type=autocast_device):
                     q, k = q.float(), k.float()
-                    s1 = einsum('b i d, b j d -> b i j', q[:, i:end], k)
+                    s1 = einsum("b i d, b j d -> b i j", q[:, i:end], k)
             else:
-                s1 = einsum('b i d, b j d -> b i j', q[:, i:end], k)
+                s1 = einsum("b i d, b j d -> b i j", q[:, i:end], k)
 
             s2 = s1.softmax(dim=-1, dtype=q.dtype)
             del s1
 
-            r1[:, i:end] = einsum('b i j, b j d -> b i d', s2, v)
+            r1[:, i:end] = einsum("b i j, b j d -> b i d", s2, v)
             del s2
 
         del q, k, v
 
-        r2 = rearrange(r1, '(b h) n d -> b n (h d)', h=h)
+        r2 = rearrange(r1, "(b h) n d -> b n (h d)", h=h)
         del r1
 
         return self.to_out(r2)
 
     return forward
+
 
 def print_model_size_breakdown(model):
     """
@@ -204,28 +224,30 @@ def print_model_size_breakdown(model):
     size_input, size_middle, size_output = 0, 0, 0
     for key, val in model.model.diffusion_model.state_dict().items():
         s = val.element_size() * val.nelement()
-        if 'input' in key:
+        if "input" in key:
             size_input += s
-        elif 'middle' in key:
+        elif "middle" in key:
             size_middle += s
-        elif 'output' in key:
+        elif "output" in key:
             size_output += s
 
-    log.info(f'model.diffusion_model (input, middle, output blocks): {mb(size_input)} Mb, {mb(size_middle)} Mb, {mb(size_output)} Mb')
-    log.info(f'model.diffusion_model (total): {mb(size_input + size_middle + size_output)} Mb')
+    log.info(
+        f"model.diffusion_model (input, middle, output blocks): {mb(size_input)} Mb, {mb(size_middle)} Mb, {mb(size_output)} Mb"
+    )
+    log.info(f"model.diffusion_model (total): {mb(size_input + size_middle + size_output)} Mb")
 
     # modelFS
     sizeFS = 0
     for _, val in model.first_stage_model.state_dict().items():
         sizeFS += val.element_size() * val.nelement()
 
-    log.info(f'model.first_stage_model: {mb(sizeFS)} Mb')
+    log.info(f"model.first_stage_model: {mb(sizeFS)} Mb")
 
     # modelCS
     sizeCS = 0
     for _, val in model.cond_stage_model.state_dict().items():
         sizeCS += val.element_size() * val.nelement()
 
-    log.info(f'model.cond_stage_model: {mb(sizeCS)} Mb')
+    log.info(f"model.cond_stage_model: {mb(sizeCS)} Mb")
 
-    log.info(f'model (TOTAL): {mb(size_input + size_middle + size_output + sizeFS + sizeCS)} Mb')
+    log.info(f"model (TOTAL): {mb(size_input + size_middle + size_output + sizeFS + sizeCS)} Mb")

--- a/sdkit/models/model_loader/vae.py
+++ b/sdkit/models/model_loader/vae.py
@@ -1,9 +1,9 @@
 import os
-import tempfile
 import traceback
+import tempfile
 
 from sdkit import Context
-from sdkit.utils import load_tensor_file, log
+from sdkit.utils import log, load_tensor_file
 
 """
 The VAE model overwrites the state_dict of model.first_stage_model.
@@ -12,9 +12,8 @@ We keep a copy of the original first-stage state_dict when a SD model is loaded,
 and restore that copy if the custom VAE is unloaded.
 """
 
-
 def load_model(context: Context, **kwargs):
-    vae_model_path = context.model_paths.get("vae")
+    vae_model_path = context.model_paths.get('vae')
 
     try:
         vae = load_tensor_file(vae_model_path)
@@ -26,29 +25,25 @@ def load_model(context: Context, **kwargs):
         _set_vae(context, vae_dict)
 
         del vae_dict
-        return {}  # we don't need to access this again
+        return {} # we don't need to access this again
     except:
         log.error(traceback.format_exc())
-        log.error(f"Could not load VAE: {vae_model_path}")
-
+        log.error(f'Could not load VAE: {vae_model_path}')
 
 def move_model_to_cpu(context: Context):
     pass
-
 
 def unload_model(context: Context, **kwargs):
     base_vae = _get_base_model_vae(context)
     _set_vae(context, base_vae)
 
-
 def _set_vae(context: Context, vae: dict):
-    if "stable-diffusion" not in context.models:
+    if 'stable-diffusion' not in context.models:
         return
 
-    model = context.models["stable-diffusion"]
+    model = context.models['stable-diffusion']
     model.first_stage_model.load_state_dict(vae, strict=False)
 
-
 def _get_base_model_vae(context: Context):
-    base_vae = os.path.join(tempfile.gettempdir(), "sd-base-vae.safetensors")
+    base_vae = os.path.join(tempfile.gettempdir(), 'sd-base-vae.safetensors')
     return load_tensor_file(base_vae)

--- a/sdkit/models/model_loader/vae.py
+++ b/sdkit/models/model_loader/vae.py
@@ -1,9 +1,9 @@
 import os
-import traceback
 import tempfile
+import traceback
 
 from sdkit import Context
-from sdkit.utils import log, load_tensor_file
+from sdkit.utils import load_tensor_file, log
 
 """
 The VAE model overwrites the state_dict of model.first_stage_model.

--- a/sdkit/models/model_loader/vae.py
+++ b/sdkit/models/model_loader/vae.py
@@ -12,8 +12,9 @@ We keep a copy of the original first-stage state_dict when a SD model is loaded,
 and restore that copy if the custom VAE is unloaded.
 """
 
+
 def load_model(context: Context, **kwargs):
-    vae_model_path = context.model_paths.get('vae')
+    vae_model_path = context.model_paths.get("vae")
 
     try:
         vae = load_tensor_file(vae_model_path)
@@ -25,25 +26,29 @@ def load_model(context: Context, **kwargs):
         _set_vae(context, vae_dict)
 
         del vae_dict
-        return {} # we don't need to access this again
+        return {}  # we don't need to access this again
     except:
         log.error(traceback.format_exc())
-        log.error(f'Could not load VAE: {vae_model_path}')
+        log.error(f"Could not load VAE: {vae_model_path}")
+
 
 def move_model_to_cpu(context: Context):
     pass
+
 
 def unload_model(context: Context, **kwargs):
     base_vae = _get_base_model_vae(context)
     _set_vae(context, base_vae)
 
+
 def _set_vae(context: Context, vae: dict):
-    if 'stable-diffusion' not in context.models:
+    if "stable-diffusion" not in context.models:
         return
 
-    model = context.models['stable-diffusion']
+    model = context.models["stable-diffusion"]
     model.first_stage_model.load_state_dict(vae, strict=False)
 
+
 def _get_base_model_vae(context: Context):
-    base_vae = os.path.join(tempfile.gettempdir(), 'sd-base-vae.safetensors')
+    base_vae = os.path.join(tempfile.gettempdir(), "sd-base-vae.safetensors")
     return load_tensor_file(base_vae)

--- a/sdkit/models/models_db/__init__.py
+++ b/sdkit/models/models_db/__init__.py
@@ -4,6 +4,7 @@ from pathlib import Path
 db = None
 index = None
 
+
 def get_models_db():
     global db
 
@@ -12,10 +13,14 @@ def get_models_db():
 
     db_path = Path(__file__).parent
     db = {}
-    with open(db_path/'stable_diffusion.json') as f: db['stable-diffusion'] = json.load(f)
-    with open(db_path/'gfpgan.json') as f: db['gfpgan'] = json.load(f)
-    with open(db_path/'realesrgan.json') as f: db['realesrgan'] = json.load(f)
+    with open(db_path / "stable_diffusion.json") as f:
+        db["stable-diffusion"] = json.load(f)
+    with open(db_path / "gfpgan.json") as f:
+        db["gfpgan"] = json.load(f)
+    with open(db_path / "realesrgan.json") as f:
+        db["realesrgan"] = json.load(f)
     return db
+
 
 def get_model_info_from_db(quick_hash=None, model_type=None, model_id=None):
     db = get_models_db()
@@ -29,11 +34,12 @@ def get_model_info_from_db(quick_hash=None, model_type=None, model_id=None):
         m = db.get(model_type, {})
         return m.get(model_id)
 
+
 def rebuild_index():
     global index
 
     db = get_models_db()
     index = {}
     for _, m in db.items():
-        module_index = {info.get('quick_hash'): info for _, info in m.items()}
+        module_index = {info.get("quick_hash"): info for _, info in m.items()}
         index.update(module_index)

--- a/sdkit/models/models_db/__init__.py
+++ b/sdkit/models/models_db/__init__.py
@@ -4,7 +4,6 @@ from pathlib import Path
 db = None
 index = None
 
-
 def get_models_db():
     global db
 
@@ -13,14 +12,10 @@ def get_models_db():
 
     db_path = Path(__file__).parent
     db = {}
-    with open(db_path / "stable_diffusion.json") as f:
-        db["stable-diffusion"] = json.load(f)
-    with open(db_path / "gfpgan.json") as f:
-        db["gfpgan"] = json.load(f)
-    with open(db_path / "realesrgan.json") as f:
-        db["realesrgan"] = json.load(f)
+    with open(db_path/'stable_diffusion.json') as f: db['stable-diffusion'] = json.load(f)
+    with open(db_path/'gfpgan.json') as f: db['gfpgan'] = json.load(f)
+    with open(db_path/'realesrgan.json') as f: db['realesrgan'] = json.load(f)
     return db
-
 
 def get_model_info_from_db(quick_hash=None, model_type=None, model_id=None):
     db = get_models_db()
@@ -34,12 +29,11 @@ def get_model_info_from_db(quick_hash=None, model_type=None, model_id=None):
         m = db.get(model_type, {})
         return m.get(model_id)
 
-
 def rebuild_index():
     global index
 
     db = get_models_db()
     index = {}
     for _, m in db.items():
-        module_index = {info.get("quick_hash"): info for _, info in m.items()}
+        module_index = {info.get('quick_hash'): info for _, info in m.items()}
         index.update(module_index)

--- a/sdkit/models/scan_models.py
+++ b/sdkit/models/scan_models.py
@@ -1,8 +1,7 @@
 import picklescan.scanner
 
-
 def scan_model(file_path):
-    """
+    '''
     Uses `picklescan.scanner.scan_file_path()` to scan and return the results.
-    """
+    '''
     return picklescan.scanner.scan_file_path(file_path)

--- a/sdkit/models/scan_models.py
+++ b/sdkit/models/scan_models.py
@@ -1,7 +1,8 @@
 import picklescan.scanner
 
+
 def scan_model(file_path):
-    '''
+    """
     Uses `picklescan.scanner.scan_file_path()` to scan and return the results.
-    '''
+    """
     return picklescan.scanner.scan_file_path(file_path)

--- a/sdkit/train/__init__.py
+++ b/sdkit/train/__init__.py
@@ -1,0 +1,1 @@
+from .merge_models import merge_models

--- a/sdkit/train/__init__.py
+++ b/sdkit/train/__init__.py
@@ -1,1 +1,0 @@
-from .merge_models import merge_models

--- a/sdkit/train/merge_models.py
+++ b/sdkit/train/merge_models.py
@@ -2,60 +2,61 @@
 
 from sdkit.utils import load_tensor_file, save_tensor_file, log
 
+
 def merge_models(model0_path: str, model1_path: str, ratio: float, out_path: str, use_fp16=True):
-    '''
+    """
     Merges (using weighted sum) and writes to the `out_path`.
 
     * model0, model1 - the first and second model files to be merged
     * ratio - the ratio of the second model. 1 means only the second model will be used.
               0 means only the first model will be used.
-    '''
+    """
 
-    log.info(f'[cyan]Merge models:[/cyan] Merging {model0_path} and {model1_path}, ratio {ratio}')
+    log.info(f"[cyan]Merge models:[/cyan] Merging {model0_path} and {model1_path}, ratio {ratio}")
     merged = merge_two_models(model0_path, model1_path, ratio, use_fp16)
 
-    log.info(f'[cyan]Merge models:[/cyan] ... saving as {out_path}')
+    log.info(f"[cyan]Merge models:[/cyan] ... saving as {out_path}")
 
     if out_path.lower().endswith(".safetensors"):
         # elldrethSOg4060Mix_v10.ckpt contains a state_dict key among all the tensors, but safetensors
         # assumes that all entries are tensors, not dicts => remove the key
-        if 'state_dict' in merged:
-           del merged['state_dict']
+        if "state_dict" in merged:
+            del merged["state_dict"]
         save_tensor_file(merged, out_path)
     else:
-        save_tensor_file({'state_dict':merged}, out_path)
+        save_tensor_file({"state_dict": merged}, out_path)
+
 
 # do this pair-wise, to avoid having to load all the models into memory
 def merge_two_models(model0, model1, alpha, use_fp16=True):
-    '''
+    """
     Returns a tensor containing the merged model. Uses weighted-sum.
 
     * model0, model1 - the first and second model files to be merged
     * alpha - a float between [0, 1]. 0 means only model0 will be used, 1 means only model1.
-    
+
     If model0 is a tensor, then model0 will be over-written with the merged data,
     and the same model0 reference will be returned.
-    '''
+    """
 
     model0_file = load_tensor_file(model0) if isinstance(model0, str) else model0
     model1_file = load_tensor_file(model1) if isinstance(model1, str) else model1
 
-    model0 = model0_file['state_dict'] if 'state_dict' in model0_file else model0_file
-    model1 = model1_file['state_dict'] if 'state_dict' in model1_file else model1_file
+    model0 = model0_file["state_dict"] if "state_dict" in model0_file else model0_file
+    model1 = model1_file["state_dict"] if "state_dict" in model1_file else model1_file
 
     # common weights
     for key in model0.keys():
-        if 'model' in key and key in model1:
+        if "model" in key and key in model1:
             model0[key] = (1 - alpha) * model0[key] + alpha * model1[key]
 
     for key in model1.keys():
-        if 'model' in key and key not in model0:
+        if "model" in key and key not in model0:
             model0[key] = model1[key]
-
 
     if use_fp16:
         for key, val in model0.items():
-            if 'model' in key:
+            if "model" in key:
                 model0[key] = val.half()
 
     # unload model1 from memory

--- a/sdkit/train/merge_models.py
+++ b/sdkit/train/merge_models.py
@@ -1,63 +1,61 @@
-# loosely inspired by
-# https://github.com/lodimasq/batch-checkpoint-merger/blob/master/batch_checkpoint_merger/main.py#L71
+# loosely inspired by https://github.com/lodimasq/batch-checkpoint-merger/blob/master/batch_checkpoint_merger/main.py#L71
 
-from sdkit.utils import load_tensor_file, log, save_tensor_file
-
+from sdkit.utils import load_tensor_file, save_tensor_file, log
 
 def merge_models(model0_path: str, model1_path: str, ratio: float, out_path: str, use_fp16=True):
-    """
+    '''
     Merges (using weighted sum) and writes to the `out_path`.
 
     * model0, model1 - the first and second model files to be merged
     * ratio - the ratio of the second model. 1 means only the second model will be used.
               0 means only the first model will be used.
-    """
+    '''
 
-    log.info(f"[cyan]Merge models:[/cyan] Merging {model0_path} and {model1_path}, ratio {ratio}")
+    log.info(f'[cyan]Merge models:[/cyan] Merging {model0_path} and {model1_path}, ratio {ratio}')
     merged = merge_two_models(model0_path, model1_path, ratio, use_fp16)
 
-    log.info(f"[cyan]Merge models:[/cyan] ... saving as {out_path}")
+    log.info(f'[cyan]Merge models:[/cyan] ... saving as {out_path}')
 
     if out_path.lower().endswith(".safetensors"):
         # elldrethSOg4060Mix_v10.ckpt contains a state_dict key among all the tensors, but safetensors
         # assumes that all entries are tensors, not dicts => remove the key
-        if "state_dict" in merged:
-            del merged["state_dict"]
+        if 'state_dict' in merged:
+           del merged['state_dict']
         save_tensor_file(merged, out_path)
     else:
-        save_tensor_file({"state_dict": merged}, out_path)
-
+        save_tensor_file({'state_dict':merged}, out_path)
 
 # do this pair-wise, to avoid having to load all the models into memory
 def merge_two_models(model0, model1, alpha, use_fp16=True):
-    """
+    '''
     Returns a tensor containing the merged model. Uses weighted-sum.
 
     * model0, model1 - the first and second model files to be merged
     * alpha - a float between [0, 1]. 0 means only model0 will be used, 1 means only model1.
-
+    
     If model0 is a tensor, then model0 will be over-written with the merged data,
     and the same model0 reference will be returned.
-    """
+    '''
 
     model0_file = load_tensor_file(model0) if isinstance(model0, str) else model0
     model1_file = load_tensor_file(model1) if isinstance(model1, str) else model1
 
-    model0 = model0_file["state_dict"] if "state_dict" in model0_file else model0_file
-    model1 = model1_file["state_dict"] if "state_dict" in model1_file else model1_file
+    model0 = model0_file['state_dict'] if 'state_dict' in model0_file else model0_file
+    model1 = model1_file['state_dict'] if 'state_dict' in model1_file else model1_file
 
     # common weights
     for key in model0.keys():
-        if "model" in key and key in model1:
+        if 'model' in key and key in model1:
             model0[key] = (1 - alpha) * model0[key] + alpha * model1[key]
 
     for key in model1.keys():
-        if "model" in key and key not in model0:
+        if 'model' in key and key not in model0:
             model0[key] = model1[key]
+
 
     if use_fp16:
         for key, val in model0.items():
-            if "model" in key:
+            if 'model' in key:
                 model0[key] = val.half()
 
     # unload model1 from memory

--- a/sdkit/train/merge_models.py
+++ b/sdkit/train/merge_models.py
@@ -1,6 +1,6 @@
 # loosely inspired by https://github.com/lodimasq/batch-checkpoint-merger/blob/master/batch_checkpoint_merger/main.py#L71
 
-from sdkit.utils import load_tensor_file, save_tensor_file, log
+from sdkit.utils import load_tensor_file, log, save_tensor_file
 
 
 def merge_models(model0_path: str, model1_path: str, ratio: float, out_path: str, use_fp16=True):

--- a/sdkit/train/merge_models.py
+++ b/sdkit/train/merge_models.py
@@ -1,6 +1,6 @@
 # loosely inspired by https://github.com/lodimasq/batch-checkpoint-merger/blob/master/batch_checkpoint_merger/main.py#L71
 
-from sdkit.utils import load_tensor_file, save_tensor_file, log
+from sdkit.utils import load_tensor_file, log, save_tensor_file
 
 
 def merge_models(

--- a/sdkit/train/merge_models.py
+++ b/sdkit/train/merge_models.py
@@ -1,11 +1,10 @@
-# loosely inspired by https://github.com/lodimasq/batch-checkpoint-merger/blob/master/batch_checkpoint_merger/main.py#L71
+# loosely inspired by
+# https://github.com/lodimasq/batch-checkpoint-merger/blob/master/batch_checkpoint_merger/main.py#L71
 
 from sdkit.utils import load_tensor_file, log, save_tensor_file
 
 
-def merge_models(
-    model0_path: str, model1_path: str, ratio: float, out_path: str, use_fp16=True
-):
+def merge_models(model0_path: str, model1_path: str, ratio: float, out_path: str, use_fp16=True):
     """
     Merges (using weighted sum) and writes to the `out_path`.
 
@@ -14,9 +13,7 @@ def merge_models(
               0 means only the first model will be used.
     """
 
-    log.info(
-        f"[cyan]Merge models:[/cyan] Merging {model0_path} and {model1_path}, ratio {ratio}"
-    )
+    log.info(f"[cyan]Merge models:[/cyan] Merging {model0_path} and {model1_path}, ratio {ratio}")
     merged = merge_two_models(model0_path, model1_path, ratio, use_fp16)
 
     log.info(f"[cyan]Merge models:[/cyan] ... saving as {out_path}")

--- a/sdkit/train/merge_models.py
+++ b/sdkit/train/merge_models.py
@@ -2,60 +2,65 @@
 
 from sdkit.utils import load_tensor_file, save_tensor_file, log
 
-def merge_models(model0_path: str, model1_path: str, ratio: float, out_path: str, use_fp16=True):
-    '''
+
+def merge_models(
+    model0_path: str, model1_path: str, ratio: float, out_path: str, use_fp16=True
+):
+    """
     Merges (using weighted sum) and writes to the `out_path`.
 
     * model0, model1 - the first and second model files to be merged
     * ratio - the ratio of the second model. 1 means only the second model will be used.
               0 means only the first model will be used.
-    '''
+    """
 
-    log.info(f'[cyan]Merge models:[/cyan] Merging {model0_path} and {model1_path}, ratio {ratio}')
+    log.info(
+        f"[cyan]Merge models:[/cyan] Merging {model0_path} and {model1_path}, ratio {ratio}"
+    )
     merged = merge_two_models(model0_path, model1_path, ratio, use_fp16)
 
-    log.info(f'[cyan]Merge models:[/cyan] ... saving as {out_path}')
+    log.info(f"[cyan]Merge models:[/cyan] ... saving as {out_path}")
 
     if out_path.lower().endswith(".safetensors"):
         # elldrethSOg4060Mix_v10.ckpt contains a state_dict key among all the tensors, but safetensors
         # assumes that all entries are tensors, not dicts => remove the key
-        if 'state_dict' in merged:
-           del merged['state_dict']
+        if "state_dict" in merged:
+            del merged["state_dict"]
         save_tensor_file(merged, out_path)
     else:
-        save_tensor_file({'state_dict':merged}, out_path)
+        save_tensor_file({"state_dict": merged}, out_path)
+
 
 # do this pair-wise, to avoid having to load all the models into memory
 def merge_two_models(model0, model1, alpha, use_fp16=True):
-    '''
+    """
     Returns a tensor containing the merged model. Uses weighted-sum.
 
     * model0, model1 - the first and second model files to be merged
     * alpha - a float between [0, 1]. 0 means only model0 will be used, 1 means only model1.
-    
+
     If model0 is a tensor, then model0 will be over-written with the merged data,
     and the same model0 reference will be returned.
-    '''
+    """
 
     model0_file = load_tensor_file(model0) if isinstance(model0, str) else model0
     model1_file = load_tensor_file(model1) if isinstance(model1, str) else model1
 
-    model0 = model0_file['state_dict'] if 'state_dict' in model0_file else model0_file
-    model1 = model1_file['state_dict'] if 'state_dict' in model1_file else model1_file
+    model0 = model0_file["state_dict"] if "state_dict" in model0_file else model0_file
+    model1 = model1_file["state_dict"] if "state_dict" in model1_file else model1_file
 
     # common weights
     for key in model0.keys():
-        if 'model' in key and key in model1:
+        if "model" in key and key in model1:
             model0[key] = (1 - alpha) * model0[key] + alpha * model1[key]
 
     for key in model1.keys():
-        if 'model' in key and key not in model0:
+        if "model" in key and key not in model0:
             model0[key] = model1[key]
-
 
     if use_fp16:
         for key, val in model0.items():
-            if 'model' in key:
+            if "model" in key:
                 model0[key] = val.half()
 
     # unload model1 from memory

--- a/sdkit/utils/__init__.py
+++ b/sdkit/utils/__init__.py
@@ -1,33 +1,53 @@
 import logging
 
-log = logging.getLogger("sdkit")
-LOG_FORMAT = "%(asctime)s.%(msecs)03d %(levelname)s %(threadName)s %(message)s"
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, datefmt="%X")
+log = logging.getLogger('sdkit')
+LOG_FORMAT = '%(asctime)s.%(msecs)03d %(levelname)s %(threadName)s %(message)s'
+logging.basicConfig(
+        level=logging.INFO,
+        format=LOG_FORMAT,
+        datefmt="%X"
+)
 
-from .file_utils import load_tensor_file, save_dicts, save_images, save_tensor_file
-from .hash_utils import hash_bytes, hash_file_quick, hash_url_quick
-from .http_utils import download_file
+from .file_utils import (
+    load_tensor_file,
+    save_tensor_file,
+    save_images,
+    save_dicts,
+)
+
+from .hash_utils import (
+    hash_bytes,
+    hash_url_quick,
+    hash_file_quick,
+)
+
 from .image_utils import (
-    apply_color_profile,
-    base64_str_to_buffer,
-    base64_str_to_img,
-    buffer_to_base64_str,
     img_to_base64_str,
     img_to_buffer,
+    buffer_to_base64_str,
+    base64_str_to_buffer,
+    base64_str_to_img,
     resize_img,
+    apply_color_profile,
 )
+
 from .latent_utils import (
-    get_image_latent_and_mask,
     img_to_tensor,
+    get_image_latent_and_mask,
     latent_samples_to_images,
 )
+
 from .memory_utils import (
     gc,
     get_device_usage,
-    get_object_id,
-    get_tensors_in_memory,
     print_largest_tensors_in_memory,
     print_tensor_info,
+    get_object_id,
     record_tensor_name,
+    get_tensors_in_memory,
     take_memory_snapshot,
+)
+
+from .http_utils import (
+    download_file,
 )

--- a/sdkit/utils/__init__.py
+++ b/sdkit/utils/__init__.py
@@ -1,5 +1,53 @@
 import logging
 
-log = logging.getLogger("sdkit")
-LOG_FORMAT = "%(asctime)s.%(msecs)03d %(levelname)s %(threadName)s %(message)s"
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, datefmt="%X")
+log = logging.getLogger('sdkit')
+LOG_FORMAT = '%(asctime)s.%(msecs)03d %(levelname)s %(threadName)s %(message)s'
+logging.basicConfig(
+        level=logging.INFO,
+        format=LOG_FORMAT,
+        datefmt="%X"
+)
+
+from .file_utils import (
+    load_tensor_file,
+    save_tensor_file,
+    save_images,
+    save_dicts,
+)
+
+from .hash_utils import (
+    hash_bytes,
+    hash_url_quick,
+    hash_file_quick,
+)
+
+from .image_utils import (
+    img_to_base64_str,
+    img_to_buffer,
+    buffer_to_base64_str,
+    base64_str_to_buffer,
+    base64_str_to_img,
+    resize_img,
+    apply_color_profile,
+)
+
+from .latent_utils import (
+    img_to_tensor,
+    get_image_latent_and_mask,
+    latent_samples_to_images,
+)
+
+from .memory_utils import (
+    gc,
+    get_device_usage,
+    print_largest_tensors_in_memory,
+    print_tensor_info,
+    get_object_id,
+    record_tensor_name,
+    get_tensors_in_memory,
+    take_memory_snapshot,
+)
+
+from .http_utils import (
+    download_file,
+)

--- a/sdkit/utils/__init__.py
+++ b/sdkit/utils/__init__.py
@@ -4,46 +4,30 @@ log = logging.getLogger("sdkit")
 LOG_FORMAT = "%(asctime)s.%(msecs)03d %(levelname)s %(threadName)s %(message)s"
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, datefmt="%X")
 
-from .file_utils import (
-    load_tensor_file,
-    save_tensor_file,
-    save_images,
-    save_dicts,
-)
-
-from .hash_utils import (
-    hash_bytes,
-    hash_url_quick,
-    hash_file_quick,
-)
-
+from .file_utils import load_tensor_file, save_dicts, save_images, save_tensor_file
+from .hash_utils import hash_bytes, hash_file_quick, hash_url_quick
+from .http_utils import download_file
 from .image_utils import (
-    img_to_base64_str,
-    img_to_buffer,
-    buffer_to_base64_str,
+    apply_color_profile,
     base64_str_to_buffer,
     base64_str_to_img,
+    buffer_to_base64_str,
+    img_to_base64_str,
+    img_to_buffer,
     resize_img,
-    apply_color_profile,
 )
-
 from .latent_utils import (
-    img_to_tensor,
     get_image_latent_and_mask,
+    img_to_tensor,
     latent_samples_to_images,
 )
-
 from .memory_utils import (
     gc,
     get_device_usage,
+    get_object_id,
+    get_tensors_in_memory,
     print_largest_tensors_in_memory,
     print_tensor_info,
-    get_object_id,
     record_tensor_name,
-    get_tensors_in_memory,
     take_memory_snapshot,
-)
-
-from .http_utils import (
-    download_file,
 )

--- a/sdkit/utils/__init__.py
+++ b/sdkit/utils/__init__.py
@@ -4,30 +4,3 @@ log = logging.getLogger("sdkit")
 LOG_FORMAT = "%(asctime)s.%(msecs)03d %(levelname)s %(threadName)s %(message)s"
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, datefmt="%X")
 
-from .file_utils import load_tensor_file, save_dicts, save_images, save_tensor_file
-from .hash_utils import hash_bytes, hash_file_quick, hash_url_quick
-from .http_utils import download_file
-from .image_utils import (
-    apply_color_profile,
-    base64_str_to_buffer,
-    base64_str_to_img,
-    buffer_to_base64_str,
-    img_to_base64_str,
-    img_to_buffer,
-    resize_img,
-)
-from .latent_utils import (
-    get_image_latent_and_mask,
-    img_to_tensor,
-    latent_samples_to_images,
-)
-from .memory_utils import (
-    gc,
-    get_device_usage,
-    get_object_id,
-    get_tensors_in_memory,
-    print_largest_tensors_in_memory,
-    print_tensor_info,
-    record_tensor_name,
-    take_memory_snapshot,
-)

--- a/sdkit/utils/__init__.py
+++ b/sdkit/utils/__init__.py
@@ -3,4 +3,3 @@ import logging
 log = logging.getLogger("sdkit")
 LOG_FORMAT = "%(asctime)s.%(msecs)03d %(levelname)s %(threadName)s %(message)s"
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, datefmt="%X")
-

--- a/sdkit/utils/__init__.py
+++ b/sdkit/utils/__init__.py
@@ -1,12 +1,8 @@
 import logging
 
-log = logging.getLogger('sdkit')
-LOG_FORMAT = '%(asctime)s.%(msecs)03d %(levelname)s %(threadName)s %(message)s'
-logging.basicConfig(
-        level=logging.INFO,
-        format=LOG_FORMAT,
-        datefmt="%X"
-)
+log = logging.getLogger("sdkit")
+LOG_FORMAT = "%(asctime)s.%(msecs)03d %(levelname)s %(threadName)s %(message)s"
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, datefmt="%X")
 
 from .file_utils import (
     load_tensor_file,

--- a/sdkit/utils/file_utils.py
+++ b/sdkit/utils/file_utils.py
@@ -7,11 +7,13 @@ import piexif.helper
 from PIL import Image, PngImagePlugin
 from PIL.PngImagePlugin import PngInfo
 
+
 def load_tensor_file(path):
     if path.lower().endswith(".safetensors"):
         return safetensors.torch.load_file(path, device="cpu")
     else:
         return torch.load(path, map_location="cpu")
+
 
 def save_tensor_file(data, path):
     if path.lower().endswith(".safetensors"):
@@ -19,8 +21,9 @@ def save_tensor_file(data, path):
     else:
         return torch.save(data, path)
 
-def save_images(images: list, dir_path: str, file_name='image', output_format='JPEG', output_quality=75):
-    '''
+
+def save_images(images: list, dir_path: str, file_name="image", output_format="JPEG", output_quality=75):
+    """
     * images: a list of of PIL.Image images to save
     * dir_path: the directory path where the images will be saved
     * file_name: the file name to save. Can be a string or a function.
@@ -29,17 +32,19 @@ def save_images(images: list, dir_path: str, file_name='image', output_format='J
           and the returned value will be used as the actual file name. e.g `def fn(i): return 'foo' + i`
     * output_format: 'JPEG' or 'PNG'
     * output_quality: an integer between 0 and 100, used for JPEG
-    '''
-    if dir_path is None: return
+    """
+    if dir_path is None:
+        return
     os.makedirs(dir_path, exist_ok=True)
 
     for i, img in enumerate(images):
-        actual_file_name = file_name(i) if callable(file_name) else f'{file_name}_{i}'
+        actual_file_name = file_name(i) if callable(file_name) else f"{file_name}_{i}"
         path = os.path.join(dir_path, actual_file_name)
-        img.save(f'{path}.{output_format.lower()}', quality=output_quality)
+        img.save(f"{path}.{output_format.lower()}", quality=output_quality)
 
-def save_dicts(entries: list, dir_path: str, file_name='data', output_format='txt', file_format=''):
-    '''
+
+def save_dicts(entries: list, dir_path: str, file_name="data", output_format="txt", file_format=""):
+    """
     * entries: a list of dictionaries
     * dir_path: the directory path where the files will be saved
     * file_name: the file name to save. Can be a string or a function.
@@ -48,30 +53,33 @@ def save_dicts(entries: list, dir_path: str, file_name='data', output_format='tx
           and the returned value will be used as the actual file name. e.g `def fn(i): return 'foo' + i`
     * output_format: 'txt', 'json', or 'embed'
         if 'embed', the metadata will be embedded in PNG files in tEXt chunks, and as EXIF UserComment for JPEG files
-    '''
-    if dir_path is None: return
+    """
+    if dir_path is None:
+        return
     os.makedirs(dir_path, exist_ok=True)
 
     for i, metadata in enumerate(entries):
-        actual_file_name = file_name(i) if callable(file_name) else f'{file_name}_{i}'
+        actual_file_name = file_name(i) if callable(file_name) else f"{file_name}_{i}"
         path = os.path.join(dir_path, actual_file_name)
 
-        if output_format.lower() == 'embed' and file_format.lower() == 'png':
-            targetImage = Image.open(f'{path}.{file_format.lower()}')
+        if output_format.lower() == "embed" and file_format.lower() == "png":
+            targetImage = Image.open(f"{path}.{file_format.lower()}")
             embedded_metadata = PngInfo()
             for key, val in metadata.items():
                 embedded_metadata.add_text(key, str(val))
-            targetImage.save(f'{path}.{file_format.lower()}', pnginfo=embedded_metadata)
-        elif output_format.lower() == 'embed' and file_format.lower() == 'jpeg':
-            targetImage = Image.open(f'{path}.{file_format.lower()}')
+            targetImage.save(f"{path}.{file_format.lower()}", pnginfo=embedded_metadata)
+        elif output_format.lower() == "embed" and file_format.lower() == "jpeg":
+            targetImage = Image.open(f"{path}.{file_format.lower()}")
             user_comment = json.dumps(metadata)
-            exif_dict = {'Exif': { piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(user_comment, encoding="unicode")}}
+            exif_dict = {
+                "Exif": {piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(user_comment, encoding="unicode")}
+            }
             exif_bytes = piexif.dump(exif_dict)
-            targetImage.save(f'{path}.{file_format.lower()}', exif=exif_bytes)
+            targetImage.save(f"{path}.{file_format.lower()}", exif=exif_bytes)
         else:
-            with open(f'{path}.{output_format.lower()}', 'w', encoding='utf-8') as f:
-                if output_format.lower() == 'txt':
+            with open(f"{path}.{output_format.lower()}", "w", encoding="utf-8") as f:
+                if output_format.lower() == "txt":
                     for key, val in metadata.items():
-                        f.write(f'{key}: {val}\n')
-                elif output_format.lower() == 'json':
+                        f.write(f"{key}: {val}\n")
+                elif output_format.lower() == "json":
                     json.dump(metadata, f, indent=2)

--- a/sdkit/utils/file_utils.py
+++ b/sdkit/utils/file_utils.py
@@ -1,11 +1,8 @@
-import os
 import json
-import torch
+import os
+
 import safetensors.torch
-import piexif
-import piexif.helper
-from PIL import Image, PngImagePlugin
-from PIL.PngImagePlugin import PngInfo
+import torch
 
 
 def load_tensor_file(path):

--- a/sdkit/utils/file_utils.py
+++ b/sdkit/utils/file_utils.py
@@ -5,7 +5,7 @@ import piexif
 import piexif.helper
 import safetensors.torch
 import torch
-from PIL import Image, PngImagePlugin
+from PIL import Image
 from PIL.PngImagePlugin import PngInfo
 
 

--- a/sdkit/utils/file_utils.py
+++ b/sdkit/utils/file_utils.py
@@ -1,9 +1,10 @@
-import os
 import json
-import torch
-import safetensors.torch
+import os
+
 import piexif
 import piexif.helper
+import safetensors.torch
+import torch
 from PIL import Image, PngImagePlugin
 from PIL.PngImagePlugin import PngInfo
 

--- a/sdkit/utils/file_utils.py
+++ b/sdkit/utils/file_utils.py
@@ -1,9 +1,11 @@
-import json
 import os
-
-import safetensors.torch
+import json
 import torch
-
+import safetensors.torch
+import piexif
+import piexif.helper
+from PIL import Image, PngImagePlugin
+from PIL.PngImagePlugin import PngInfo
 
 def load_tensor_file(path):
     if path.lower().endswith(".safetensors"):
@@ -11,22 +13,14 @@ def load_tensor_file(path):
     else:
         return torch.load(path, map_location="cpu")
 
-
 def save_tensor_file(data, path):
     if path.lower().endswith(".safetensors"):
         return safetensors.torch.save_file(data, path, metadata={"format": "pt"})
     else:
         return torch.save(data, path)
 
-
-def save_images(
-    images: list,
-    dir_path: str,
-    file_name="image",
-    output_format="JPEG",
-    output_quality=75,
-):
-    """
+def save_images(images: list, dir_path: str, file_name='image', output_format='JPEG', output_quality=75):
+    '''
     * images: a list of of PIL.Image images to save
     * dir_path: the directory path where the images will be saved
     * file_name: the file name to save. Can be a string or a function.
@@ -35,39 +29,49 @@ def save_images(
           and the returned value will be used as the actual file name. e.g `def fn(i): return 'foo' + i`
     * output_format: 'JPEG' or 'PNG'
     * output_quality: an integer between 0 and 100, used for JPEG
-    """
-    if dir_path is None:
-        return
+    '''
+    if dir_path is None: return
     os.makedirs(dir_path, exist_ok=True)
 
     for i, img in enumerate(images):
-        actual_file_name = file_name(i) if callable(file_name) else f"{file_name}_{i}"
+        actual_file_name = file_name(i) if callable(file_name) else f'{file_name}_{i}'
         path = os.path.join(dir_path, actual_file_name)
-        img.save(f"{path}.{output_format.lower()}", quality=output_quality)
+        img.save(f'{path}.{output_format.lower()}', quality=output_quality)
 
-
-def save_dicts(entries: list, dir_path: str, file_name="data", output_format="txt"):
-    """
+def save_dicts(entries: list, dir_path: str, file_name='data', output_format='txt', file_format=''):
+    '''
     * entries: a list of dictionaries
     * dir_path: the directory path where the files will be saved
     * file_name: the file name to save. Can be a string or a function.
         if a string, the actual file name will be `{file_name}_{index}`.
         if a function, the callback function will be passed the `index` (int),
           and the returned value will be used as the actual file name. e.g `def fn(i): return 'foo' + i`
-    * output_format: 'txt' or 'json'
-    """
-    if output_format.lower() not in ["json", "txt"]:
-        return
-    if dir_path is None:
-        return
+    * output_format: 'txt', 'json', or 'embed'
+        if 'embed', the metadata will be embedded in PNG files in tEXt chunks, and as EXIF UserComment for JPEG files
+    '''
+    if dir_path is None: return
     os.makedirs(dir_path, exist_ok=True)
 
     for i, metadata in enumerate(entries):
-        actual_file_name = file_name(i) if callable(file_name) else f"{file_name}_{i}"
+        actual_file_name = file_name(i) if callable(file_name) else f'{file_name}_{i}'
         path = os.path.join(dir_path, actual_file_name)
-        with open(f"{path}.{output_format.lower()}", "w", encoding="utf-8") as f:
-            if output_format.lower() == "txt":
-                for key, val in metadata.items():
-                    f.write(f"{key}: {val}\n")
-            elif output_format.lower() == "json":
-                json.dump(metadata, f, indent=2)
+
+        if output_format.lower() == 'embed' and file_format.lower() == 'png':
+            targetImage = Image.open(f'{path}.{file_format.lower()}')
+            embedded_metadata = PngInfo()
+            for key, val in metadata.items():
+                embedded_metadata.add_text(key, str(val))
+            targetImage.save(f'{path}.{file_format.lower()}', pnginfo=embedded_metadata)
+        elif output_format.lower() == 'embed' and file_format.lower() == 'jpeg':
+            targetImage = Image.open(f'{path}.{file_format.lower()}')
+            user_comment = json.dumps(metadata)
+            exif_dict = {'Exif': { piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(user_comment, encoding="unicode")}}
+            exif_bytes = piexif.dump(exif_dict)
+            targetImage.save(f'{path}.{file_format.lower()}', exif=exif_bytes)
+        else:
+            with open(f'{path}.{output_format.lower()}', 'w', encoding='utf-8') as f:
+                if output_format.lower() == 'txt':
+                    for key, val in metadata.items():
+                        f.write(f'{key}: {val}\n')
+                elif output_format.lower() == 'json':
+                    json.dump(metadata, f, indent=2)

--- a/sdkit/utils/file_utils.py
+++ b/sdkit/utils/file_utils.py
@@ -7,11 +7,13 @@ import piexif.helper
 from PIL import Image, PngImagePlugin
 from PIL.PngImagePlugin import PngInfo
 
+
 def load_tensor_file(path):
     if path.lower().endswith(".safetensors"):
         return safetensors.torch.load_file(path, device="cpu")
     else:
         return torch.load(path, map_location="cpu")
+
 
 def save_tensor_file(data, path):
     if path.lower().endswith(".safetensors"):
@@ -19,8 +21,15 @@ def save_tensor_file(data, path):
     else:
         return torch.save(data, path)
 
-def save_images(images: list, dir_path: str, file_name='image', output_format='JPEG', output_quality=75):
-    '''
+
+def save_images(
+    images: list,
+    dir_path: str,
+    file_name="image",
+    output_format="JPEG",
+    output_quality=75,
+):
+    """
     * images: a list of of PIL.Image images to save
     * dir_path: the directory path where the images will be saved
     * file_name: the file name to save. Can be a string or a function.
@@ -29,49 +38,39 @@ def save_images(images: list, dir_path: str, file_name='image', output_format='J
           and the returned value will be used as the actual file name. e.g `def fn(i): return 'foo' + i`
     * output_format: 'JPEG' or 'PNG'
     * output_quality: an integer between 0 and 100, used for JPEG
-    '''
-    if dir_path is None: return
+    """
+    if dir_path is None:
+        return
     os.makedirs(dir_path, exist_ok=True)
 
     for i, img in enumerate(images):
-        actual_file_name = file_name(i) if callable(file_name) else f'{file_name}_{i}'
+        actual_file_name = file_name(i) if callable(file_name) else f"{file_name}_{i}"
         path = os.path.join(dir_path, actual_file_name)
-        img.save(f'{path}.{output_format.lower()}', quality=output_quality)
+        img.save(f"{path}.{output_format.lower()}", quality=output_quality)
 
-def save_dicts(entries: list, dir_path: str, file_name='data', output_format='txt', file_format=''):
-    '''
+
+def save_dicts(entries: list, dir_path: str, file_name="data", output_format="txt"):
+    """
     * entries: a list of dictionaries
     * dir_path: the directory path where the files will be saved
     * file_name: the file name to save. Can be a string or a function.
         if a string, the actual file name will be `{file_name}_{index}`.
         if a function, the callback function will be passed the `index` (int),
           and the returned value will be used as the actual file name. e.g `def fn(i): return 'foo' + i`
-    * output_format: 'txt', 'json', or 'embed'
-        if 'embed', the metadata will be embedded in PNG files in tEXt chunks, and as EXIF UserComment for JPEG files
-    '''
-    if dir_path is None: return
+    * output_format: 'txt' or 'json'
+    """
+    if output_format.lower() not in ["json", "txt"]:
+        return
+    if dir_path is None:
+        return
     os.makedirs(dir_path, exist_ok=True)
 
     for i, metadata in enumerate(entries):
-        actual_file_name = file_name(i) if callable(file_name) else f'{file_name}_{i}'
+        actual_file_name = file_name(i) if callable(file_name) else f"{file_name}_{i}"
         path = os.path.join(dir_path, actual_file_name)
-
-        if output_format.lower() == 'embed' and file_format.lower() == 'png':
-            targetImage = Image.open(f'{path}.{file_format.lower()}')
-            embedded_metadata = PngInfo()
-            for key, val in metadata.items():
-                embedded_metadata.add_text(key, str(val))
-            targetImage.save(f'{path}.{file_format.lower()}', pnginfo=embedded_metadata)
-        elif output_format.lower() == 'embed' and file_format.lower() == 'jpeg':
-            targetImage = Image.open(f'{path}.{file_format.lower()}')
-            user_comment = json.dumps(metadata)
-            exif_dict = {'Exif': { piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(user_comment, encoding="unicode")}}
-            exif_bytes = piexif.dump(exif_dict)
-            targetImage.save(f'{path}.{file_format.lower()}', exif=exif_bytes)
-        else:
-            with open(f'{path}.{output_format.lower()}', 'w', encoding='utf-8') as f:
-                if output_format.lower() == 'txt':
-                    for key, val in metadata.items():
-                        f.write(f'{key}: {val}\n')
-                elif output_format.lower() == 'json':
-                    json.dump(metadata, f, indent=2)
+        with open(f"{path}.{output_format.lower()}", "w", encoding="utf-8") as f:
+            if output_format.lower() == "txt":
+                for key, val in metadata.items():
+                    f.write(f"{key}: {val}\n")
+            elif output_format.lower() == "json":
+                json.dump(metadata, f, indent=2)

--- a/sdkit/utils/hash_utils.py
+++ b/sdkit/utils/hash_utils.py
@@ -2,19 +2,25 @@ import os
 import hashlib
 import requests
 
+
 def hash_url_quick(url):
     from sdkit.utils import log
-    log.debug(f'hashing url: {url}')
+
+    log.debug(f"hashing url: {url}")
 
     def get_size():
         res = requests.get(url, stream=True)
-        size = int(res.headers['content-length']) # fail loudly if the url doesn't return a content-length header
-        log.debug(f'total size: {size}')
+        size = int(
+            res.headers["content-length"]
+        )  # fail loudly if the url doesn't return a content-length header
+        log.debug(f"total size: {size}")
         return size
 
     def read_bytes(offset: int, count: int):
         res = requests.get(url, headers={"Range": f"bytes={offset}-{offset+count-1}"})
-        log.debug(f'read byte range. offset: {offset}, count: {count}, actual count: {len(res.content)}')
+        log.debug(
+            f"read byte range. offset: {offset}, count: {count}, actual count: {len(res.content)}"
+        )
         return res.content
 
     return compute_quick_hash(
@@ -22,20 +28,24 @@ def hash_url_quick(url):
         read_bytes_fn=read_bytes,
     )
 
+
 def hash_file_quick(file_path):
     from sdkit.utils import log
-    log.debug(f'hashing file: {file_path}')
+
+    log.debug(f"hashing file: {file_path}")
 
     def get_size():
         size = os.path.getsize(file_path)
-        log.debug(f'total size: {size}')
+        log.debug(f"total size: {size}")
         return size
 
     def read_bytes(offset: int, count: int):
-        with open(file_path, 'rb') as f:
+        with open(file_path, "rb") as f:
             f.seek(offset)
             bytes = f.read(count)
-            log.debug(f'read byte range. offset: {offset}, count: {count}, actual count: {len(bytes)}')
+            log.debug(
+                f"read byte range. offset: {offset}, count: {count}, actual count: {len(bytes)}"
+            )
             return bytes
 
     return compute_quick_hash(
@@ -43,8 +53,9 @@ def hash_file_quick(file_path):
         read_bytes_fn=read_bytes,
     )
 
+
 def compute_quick_hash(total_size_fn, read_bytes_fn):
-    '''
+    """
     quick-hash logic:
     - read 64k chunks from the start, middle and end, and hash them
     - start offset: 1 MB
@@ -52,14 +63,15 @@ def compute_quick_hash(total_size_fn, read_bytes_fn):
     - end offset: -1 MB
 
     Do not use if the file size is less than 3 MB
-    '''
+    """
     total_size = total_size_fn()
 
     start_bytes = read_bytes_fn(offset=0x100000, count=0x10000)
-    middle_bytes = read_bytes_fn(offset=int(total_size/2), count=0x10000)
+    middle_bytes = read_bytes_fn(offset=int(total_size / 2), count=0x10000)
     end_bytes = read_bytes_fn(offset=total_size - 0x100000, count=0x10000)
 
     return hash_bytes(start_bytes + middle_bytes + end_bytes)
+
 
 def hash_bytes(bytes):
     return hashlib.sha256(bytes).hexdigest()

--- a/sdkit/utils/hash_utils.py
+++ b/sdkit/utils/hash_utils.py
@@ -2,19 +2,21 @@ import os
 import hashlib
 import requests
 
+
 def hash_url_quick(url):
     from sdkit.utils import log
-    log.debug(f'hashing url: {url}')
+
+    log.debug(f"hashing url: {url}")
 
     def get_size():
         res = requests.get(url, stream=True)
-        size = int(res.headers['content-length']) # fail loudly if the url doesn't return a content-length header
-        log.debug(f'total size: {size}')
+        size = int(res.headers["content-length"])  # fail loudly if the url doesn't return a content-length header
+        log.debug(f"total size: {size}")
         return size
 
     def read_bytes(offset: int, count: int):
         res = requests.get(url, headers={"Range": f"bytes={offset}-{offset+count-1}"})
-        log.debug(f'read byte range. offset: {offset}, count: {count}, actual count: {len(res.content)}')
+        log.debug(f"read byte range. offset: {offset}, count: {count}, actual count: {len(res.content)}")
         return res.content
 
     return compute_quick_hash(
@@ -22,20 +24,22 @@ def hash_url_quick(url):
         read_bytes_fn=read_bytes,
     )
 
+
 def hash_file_quick(file_path):
     from sdkit.utils import log
-    log.debug(f'hashing file: {file_path}')
+
+    log.debug(f"hashing file: {file_path}")
 
     def get_size():
         size = os.path.getsize(file_path)
-        log.debug(f'total size: {size}')
+        log.debug(f"total size: {size}")
         return size
 
     def read_bytes(offset: int, count: int):
-        with open(file_path, 'rb') as f:
+        with open(file_path, "rb") as f:
             f.seek(offset)
             bytes = f.read(count)
-            log.debug(f'read byte range. offset: {offset}, count: {count}, actual count: {len(bytes)}')
+            log.debug(f"read byte range. offset: {offset}, count: {count}, actual count: {len(bytes)}")
             return bytes
 
     return compute_quick_hash(
@@ -43,8 +47,9 @@ def hash_file_quick(file_path):
         read_bytes_fn=read_bytes,
     )
 
+
 def compute_quick_hash(total_size_fn, read_bytes_fn):
-    '''
+    """
     quick-hash logic:
     - read 64k chunks from the start, middle and end, and hash them
     - start offset: 1 MB
@@ -52,14 +57,15 @@ def compute_quick_hash(total_size_fn, read_bytes_fn):
     - end offset: -1 MB
 
     Do not use if the file size is less than 3 MB
-    '''
+    """
     total_size = total_size_fn()
 
     start_bytes = read_bytes_fn(offset=0x100000, count=0x10000)
-    middle_bytes = read_bytes_fn(offset=int(total_size/2), count=0x10000)
+    middle_bytes = read_bytes_fn(offset=int(total_size / 2), count=0x10000)
     end_bytes = read_bytes_fn(offset=total_size - 0x100000, count=0x10000)
 
     return hash_bytes(start_bytes + middle_bytes + end_bytes)
+
 
 def hash_bytes(bytes):
     return hashlib.sha256(bytes).hexdigest()

--- a/sdkit/utils/hash_utils.py
+++ b/sdkit/utils/hash_utils.py
@@ -1,23 +1,20 @@
-import hashlib
 import os
-
+import hashlib
 import requests
-
 
 def hash_url_quick(url):
     from sdkit.utils import log
-
-    log.debug(f"hashing url: {url}")
+    log.debug(f'hashing url: {url}')
 
     def get_size():
         res = requests.get(url, stream=True)
-        size = int(res.headers["content-length"])  # fail loudly if the url doesn't return a content-length header
-        log.debug(f"total size: {size}")
+        size = int(res.headers['content-length']) # fail loudly if the url doesn't return a content-length header
+        log.debug(f'total size: {size}')
         return size
 
     def read_bytes(offset: int, count: int):
         res = requests.get(url, headers={"Range": f"bytes={offset}-{offset+count-1}"})
-        log.debug(f"read byte range. offset: {offset}, count: {count}, actual count: {len(res.content)}")
+        log.debug(f'read byte range. offset: {offset}, count: {count}, actual count: {len(res.content)}')
         return res.content
 
     return compute_quick_hash(
@@ -25,22 +22,20 @@ def hash_url_quick(url):
         read_bytes_fn=read_bytes,
     )
 
-
 def hash_file_quick(file_path):
     from sdkit.utils import log
-
-    log.debug(f"hashing file: {file_path}")
+    log.debug(f'hashing file: {file_path}')
 
     def get_size():
         size = os.path.getsize(file_path)
-        log.debug(f"total size: {size}")
+        log.debug(f'total size: {size}')
         return size
 
     def read_bytes(offset: int, count: int):
-        with open(file_path, "rb") as f:
+        with open(file_path, 'rb') as f:
             f.seek(offset)
             bytes = f.read(count)
-            log.debug(f"read byte range. offset: {offset}, count: {count}, actual count: {len(bytes)}")
+            log.debug(f'read byte range. offset: {offset}, count: {count}, actual count: {len(bytes)}')
             return bytes
 
     return compute_quick_hash(
@@ -48,9 +43,8 @@ def hash_file_quick(file_path):
         read_bytes_fn=read_bytes,
     )
 
-
 def compute_quick_hash(total_size_fn, read_bytes_fn):
-    """
+    '''
     quick-hash logic:
     - read 64k chunks from the start, middle and end, and hash them
     - start offset: 1 MB
@@ -58,15 +52,14 @@ def compute_quick_hash(total_size_fn, read_bytes_fn):
     - end offset: -1 MB
 
     Do not use if the file size is less than 3 MB
-    """
+    '''
     total_size = total_size_fn()
 
     start_bytes = read_bytes_fn(offset=0x100000, count=0x10000)
-    middle_bytes = read_bytes_fn(offset=int(total_size / 2), count=0x10000)
+    middle_bytes = read_bytes_fn(offset=int(total_size/2), count=0x10000)
     end_bytes = read_bytes_fn(offset=total_size - 0x100000, count=0x10000)
 
     return hash_bytes(start_bytes + middle_bytes + end_bytes)
-
 
 def hash_bytes(bytes):
     return hashlib.sha256(bytes).hexdigest()

--- a/sdkit/utils/hash_utils.py
+++ b/sdkit/utils/hash_utils.py
@@ -1,5 +1,6 @@
-import os
 import hashlib
+import os
+
 import requests
 
 

--- a/sdkit/utils/hash_utils.py
+++ b/sdkit/utils/hash_utils.py
@@ -11,17 +11,13 @@ def hash_url_quick(url):
 
     def get_size():
         res = requests.get(url, stream=True)
-        size = int(
-            res.headers["content-length"]
-        )  # fail loudly if the url doesn't return a content-length header
+        size = int(res.headers["content-length"])  # fail loudly if the url doesn't return a content-length header
         log.debug(f"total size: {size}")
         return size
 
     def read_bytes(offset: int, count: int):
         res = requests.get(url, headers={"Range": f"bytes={offset}-{offset+count-1}"})
-        log.debug(
-            f"read byte range. offset: {offset}, count: {count}, actual count: {len(res.content)}"
-        )
+        log.debug(f"read byte range. offset: {offset}, count: {count}, actual count: {len(res.content)}")
         return res.content
 
     return compute_quick_hash(
@@ -44,9 +40,7 @@ def hash_file_quick(file_path):
         with open(file_path, "rb") as f:
             f.seek(offset)
             bytes = f.read(count)
-            log.debug(
-                f"read byte range. offset: {offset}, count: {count}, actual count: {len(bytes)}"
-            )
+            log.debug(f"read byte range. offset: {offset}, count: {count}, actual count: {len(bytes)}")
             return bytes
 
     return compute_quick_hash(

--- a/sdkit/utils/http_utils.py
+++ b/sdkit/utils/http_utils.py
@@ -3,27 +3,41 @@ import os
 from tqdm import tqdm
 from shutil import copyfileobj
 
+
 def download_file(url: str, out_path: str):
-    '''
+    """
     Features:
     * Downloads large files (without storing them in memory)
     * Resumes downloads from the bytes it has downloaded already
     * Shows a progress bar
 
     The remote server needs to support the `Range` header, for resume to work.
-    '''
+    """
     from sdkit.utils import log
 
     start_offset = 0 if not os.path.exists(out_path) else os.path.getsize(out_path)
     res = requests.get(url, stream=True)
-    if not res.ok: return
-    total_bytes = int(res.headers.get('Content-Length', '0'))
+    if not res.ok:
+        return
+    total_bytes = int(res.headers.get("Content-Length", "0"))
 
-    res = requests.get(url, stream=True, headers={'Range': f'bytes={start_offset}-', 'Accept-Encoding': 'identity'})
-    if not res.ok: return
+    res = requests.get(
+        url,
+        stream=True,
+        headers={"Range": f"bytes={start_offset}-", "Accept-Encoding": "identity"},
+    )
+    if not res.ok:
+        return
 
-    write_mode = 'wb' if start_offset == 0 else 'ab'
+    write_mode = "wb" if start_offset == 0 else "ab"
 
-    log.info(f'Downloading {url} to {out_path}')
-    with open(out_path, write_mode) as f, tqdm.wrapattr(res.raw, 'read', initial=start_offset, total=total_bytes, desc='Downloading', colour='green') as res_stream:
+    log.info(f"Downloading {url} to {out_path}")
+    with open(out_path, write_mode) as f, tqdm.wrapattr(
+        res.raw,
+        "read",
+        initial=start_offset,
+        total=total_bytes,
+        desc="Downloading",
+        colour="green",
+    ) as res_stream:
         copyfileobj(res_stream, f)

--- a/sdkit/utils/http_utils.py
+++ b/sdkit/utils/http_utils.py
@@ -3,27 +3,32 @@ import os
 from tqdm import tqdm
 from shutil import copyfileobj
 
+
 def download_file(url: str, out_path: str):
-    '''
+    """
     Features:
     * Downloads large files (without storing them in memory)
     * Resumes downloads from the bytes it has downloaded already
     * Shows a progress bar
 
     The remote server needs to support the `Range` header, for resume to work.
-    '''
+    """
     from sdkit.utils import log
 
     start_offset = 0 if not os.path.exists(out_path) else os.path.getsize(out_path)
     res = requests.get(url, stream=True)
-    if not res.ok: return
-    total_bytes = int(res.headers.get('Content-Length', '0'))
+    if not res.ok:
+        return
+    total_bytes = int(res.headers.get("Content-Length", "0"))
 
-    res = requests.get(url, stream=True, headers={'Range': f'bytes={start_offset}-', 'Accept-Encoding': 'identity'})
-    if not res.ok: return
+    res = requests.get(url, stream=True, headers={"Range": f"bytes={start_offset}-", "Accept-Encoding": "identity"})
+    if not res.ok:
+        return
 
-    write_mode = 'wb' if start_offset == 0 else 'ab'
+    write_mode = "wb" if start_offset == 0 else "ab"
 
-    log.info(f'Downloading {url} to {out_path}')
-    with open(out_path, write_mode) as f, tqdm.wrapattr(res.raw, 'read', initial=start_offset, total=total_bytes, desc='Downloading', colour='green') as res_stream:
+    log.info(f"Downloading {url} to {out_path}")
+    with open(out_path, write_mode) as f, tqdm.wrapattr(
+        res.raw, "read", initial=start_offset, total=total_bytes, desc="Downloading", colour="green"
+    ) as res_stream:
         copyfileobj(res_stream, f)

--- a/sdkit/utils/http_utils.py
+++ b/sdkit/utils/http_utils.py
@@ -1,44 +1,29 @@
+import requests
 import os
+from tqdm import tqdm
 from shutil import copyfileobj
 
-import requests
-from tqdm import tqdm
-
-
 def download_file(url: str, out_path: str):
-    """
+    '''
     Features:
     * Downloads large files (without storing them in memory)
     * Resumes downloads from the bytes it has downloaded already
     * Shows a progress bar
 
     The remote server needs to support the `Range` header, for resume to work.
-    """
+    '''
     from sdkit.utils import log
 
     start_offset = 0 if not os.path.exists(out_path) else os.path.getsize(out_path)
     res = requests.get(url, stream=True)
-    if not res.ok:
-        return
-    total_bytes = int(res.headers.get("Content-Length", "0"))
+    if not res.ok: return
+    total_bytes = int(res.headers.get('Content-Length', '0'))
 
-    res = requests.get(
-        url,
-        stream=True,
-        headers={"Range": f"bytes={start_offset}-", "Accept-Encoding": "identity"},
-    )
-    if not res.ok:
-        return
+    res = requests.get(url, stream=True, headers={'Range': f'bytes={start_offset}-', 'Accept-Encoding': 'identity'})
+    if not res.ok: return
 
-    write_mode = "wb" if start_offset == 0 else "ab"
+    write_mode = 'wb' if start_offset == 0 else 'ab'
 
-    log.info(f"Downloading {url} to {out_path}")
-    with open(out_path, write_mode) as f, tqdm.wrapattr(
-        res.raw,
-        "read",
-        initial=start_offset,
-        total=total_bytes,
-        desc="Downloading",
-        colour="green",
-    ) as res_stream:
+    log.info(f'Downloading {url} to {out_path}')
+    with open(out_path, write_mode) as f, tqdm.wrapattr(res.raw, 'read', initial=start_offset, total=total_bytes, desc='Downloading', colour='green') as res_stream:
         copyfileobj(res_stream, f)

--- a/sdkit/utils/http_utils.py
+++ b/sdkit/utils/http_utils.py
@@ -1,7 +1,8 @@
-import requests
 import os
-from tqdm import tqdm
 from shutil import copyfileobj
+
+import requests
+from tqdm import tqdm
 
 
 def download_file(url: str, out_path: str):

--- a/sdkit/utils/image_utils.py
+++ b/sdkit/utils/image_utils.py
@@ -1,17 +1,14 @@
+import numpy as np
+import cv2
+from skimage import exposure
 import base64
 from io import BytesIO
-
-import cv2
-import numpy as np
 from PIL import Image
-from skimage import exposure
-
 
 # https://stackoverflow.com/a/61114178
 def img_to_base64_str(img, output_format="PNG", output_quality=75):
     buffered = img_to_buffer(img, output_format, output_quality=output_quality)
     return buffer_to_base64_str(buffered, output_format)
-
 
 def img_to_buffer(img, output_format="PNG", output_quality=75):
     buffered = BytesIO()
@@ -22,7 +19,6 @@ def img_to_buffer(img, output_format="PNG", output_quality=75):
     buffered.seek(0)
     return buffered
 
-
 def buffer_to_base64_str(buffered, output_format="PNG"):
     buffered.seek(0)
     img_byte = buffered.getvalue()
@@ -30,20 +26,17 @@ def buffer_to_base64_str(buffered, output_format="PNG"):
     img_str = f"data:{mime_type};base64," + base64.b64encode(img_byte).decode()
     return img_str
 
-
 def base64_str_to_buffer(img_str):
     mime_type = "image/png" if img_str.startswith("data:image/png;") else "image/jpeg"
-    img_str = img_str[len(f"data:{mime_type};base64,") :]
+    img_str = img_str[len(f"data:{mime_type};base64,"):]
     data = base64.b64decode(img_str)
     buffered = BytesIO(data)
     return buffered
-
 
 def base64_str_to_img(img_str):
     buffered = base64_str_to_buffer(img_str)
     img = Image.open(buffered)
     return img
-
 
 def resize_img(img: Image, desired_width, desired_height, clamp_to_64=False):
     w, h = img.size
@@ -55,7 +48,6 @@ def resize_img(img: Image, desired_width, desired_height, clamp_to_64=False):
         w, h = map(lambda x: x - x % 64, (w, h))  # resize to integer multiple of 64
 
     return img.resize((w, h), resample=Image.Resampling.LANCZOS)
-
 
 def apply_color_profile(orig_image: Image, image_to_modify: Image):
     reference = cv2.cvtColor(np.asarray(orig_image), cv2.COLOR_RGB2LAB)

--- a/sdkit/utils/image_utils.py
+++ b/sdkit/utils/image_utils.py
@@ -1,9 +1,10 @@
-import numpy as np
-import cv2
-from skimage import exposure
 import base64
 from io import BytesIO
+
+import cv2
+import numpy as np
 from PIL import Image
+from skimage import exposure
 
 
 # https://stackoverflow.com/a/61114178

--- a/sdkit/utils/image_utils.py
+++ b/sdkit/utils/image_utils.py
@@ -5,10 +5,12 @@ import base64
 from io import BytesIO
 from PIL import Image
 
+
 # https://stackoverflow.com/a/61114178
 def img_to_base64_str(img, output_format="PNG", output_quality=75):
     buffered = img_to_buffer(img, output_format, output_quality=output_quality)
     return buffer_to_base64_str(buffered, output_format)
+
 
 def img_to_buffer(img, output_format="PNG", output_quality=75):
     buffered = BytesIO()
@@ -19,6 +21,7 @@ def img_to_buffer(img, output_format="PNG", output_quality=75):
     buffered.seek(0)
     return buffered
 
+
 def buffer_to_base64_str(buffered, output_format="PNG"):
     buffered.seek(0)
     img_byte = buffered.getvalue()
@@ -26,17 +29,20 @@ def buffer_to_base64_str(buffered, output_format="PNG"):
     img_str = f"data:{mime_type};base64," + base64.b64encode(img_byte).decode()
     return img_str
 
+
 def base64_str_to_buffer(img_str):
     mime_type = "image/png" if img_str.startswith("data:image/png;") else "image/jpeg"
-    img_str = img_str[len(f"data:{mime_type};base64,"):]
+    img_str = img_str[len(f"data:{mime_type};base64,") :]
     data = base64.b64decode(img_str)
     buffered = BytesIO(data)
     return buffered
+
 
 def base64_str_to_img(img_str):
     buffered = base64_str_to_buffer(img_str)
     img = Image.open(buffered)
     return img
+
 
 def resize_img(img: Image, desired_width, desired_height, clamp_to_64=False):
     w, h = img.size
@@ -48,6 +54,7 @@ def resize_img(img: Image, desired_width, desired_height, clamp_to_64=False):
         w, h = map(lambda x: x - x % 64, (w, h))  # resize to integer multiple of 64
 
     return img.resize((w, h), resample=Image.Resampling.LANCZOS)
+
 
 def apply_color_profile(orig_image: Image, image_to_modify: Image):
     reference = cv2.cvtColor(np.asarray(orig_image), cv2.COLOR_RGB2LAB)

--- a/sdkit/utils/latent_utils.py
+++ b/sdkit/utils/latent_utils.py
@@ -5,6 +5,7 @@ from einops import repeat, rearrange
 
 from sdkit import Context
 
+
 def img_to_tensor(img: Image, batch_size, device, half_precision: bool, shift_range=False, unsqueeze=False):
     if img is None:
         return None
@@ -12,7 +13,7 @@ def img_to_tensor(img: Image, batch_size, device, half_precision: bool, shift_ra
     img = np.array(img).astype(np.float32) / 255.0
     img = img[None].transpose(0, 3, 1, 2)
     img = torch.from_numpy(img)
-    img = 2. * img - 1. if shift_range else img
+    img = 2.0 * img - 1.0 if shift_range else img
     img = img.to(device)
 
     if device != "cpu" and half_precision:
@@ -21,39 +22,43 @@ def img_to_tensor(img: Image, batch_size, device, half_precision: bool, shift_ra
     if unsqueeze:
         img = img[0][0].unsqueeze(0).repeat(4, 1, 1).unsqueeze(0)
 
-    img = repeat(img, '1 ... -> b ...', b=batch_size)
+    img = repeat(img, "1 ... -> b ...", b=batch_size)
 
     return img
+
 
 def get_image_latent_and_mask(context: Context, image: Image, mask: Image, desired_width, desired_height, batch_size):
     """
     Assumes model is on the correct device
     """
     from .image_utils import resize_img
-    if image is None or 'stable-diffusion' not in context.models:
+
+    if image is None or "stable-diffusion" not in context.models:
         return None, None
 
-    model = context.models['stable-diffusion']
+    model = context.models["stable-diffusion"]
 
-    image = image.convert('RGB')
+    image = image.convert("RGB")
     image = resize_img(image, desired_width, desired_height, clamp_to_64=True)
     image = img_to_tensor(image, batch_size, context.device, context.half_precision, shift_range=True)
-    image = model.get_first_stage_encoding(model.encode_first_stage(image)) # move to latent space
+    image = model.get_first_stage_encoding(model.encode_first_stage(image))  # move to latent space
 
     if mask is None:
         return image, None
 
-    mask = mask.convert('RGB')
+    mask = mask.convert("RGB")
     mask = resize_img(mask, image.shape[3], image.shape[2])
     mask = ImageOps.invert(mask)
     mask = img_to_tensor(mask, batch_size, context.device, context.half_precision, unsqueeze=True)
 
     return image, mask
 
-def latent_samples_to_images(context: Context, samples):
-    model = context.models['stable-diffusion']
 
-    if context.half_precision and samples.dtype != torch.float16: samples = samples.half()
+def latent_samples_to_images(context: Context, samples):
+    model = context.models["stable-diffusion"]
+
+    if context.half_precision and samples.dtype != torch.float16:
+        samples = samples.half()
 
     samples = model.decode_first_stage(samples)
     samples = torch.clamp((samples + 1.0) / 2.0, min=0.0, max=1.0)

--- a/sdkit/utils/latent_utils.py
+++ b/sdkit/utils/latent_utils.py
@@ -1,26 +1,18 @@
 import numpy as np
 import torch
-from einops import rearrange, repeat
 from PIL import Image, ImageOps
+from einops import repeat, rearrange
 
 from sdkit import Context
 
-
-def img_to_tensor(
-    img: Image,
-    batch_size,
-    device,
-    half_precision: bool,
-    shift_range=False,
-    unsqueeze=False,
-):
+def img_to_tensor(img: Image, batch_size, device, half_precision: bool, shift_range=False, unsqueeze=False):
     if img is None:
         return None
 
     img = np.array(img).astype(np.float32) / 255.0
     img = img[None].transpose(0, 3, 1, 2)
     img = torch.from_numpy(img)
-    img = 2.0 * img - 1.0 if shift_range else img
+    img = 2. * img - 1. if shift_range else img
     img = img.to(device)
 
     if device != "cpu" and half_precision:
@@ -29,50 +21,39 @@ def img_to_tensor(
     if unsqueeze:
         img = img[0][0].unsqueeze(0).repeat(4, 1, 1).unsqueeze(0)
 
-    img = repeat(img, "1 ... -> b ...", b=batch_size)
+    img = repeat(img, '1 ... -> b ...', b=batch_size)
 
     return img
 
-
-def get_image_latent_and_mask(
-    context: Context,
-    image: Image,
-    mask: Image,
-    desired_width,
-    desired_height,
-    batch_size,
-):
+def get_image_latent_and_mask(context: Context, image: Image, mask: Image, desired_width, desired_height, batch_size):
     """
     Assumes model is on the correct device
     """
     from .image_utils import resize_img
-
-    if image is None or "stable-diffusion" not in context.models:
+    if image is None or 'stable-diffusion' not in context.models:
         return None, None
 
-    model = context.models["stable-diffusion"]
+    model = context.models['stable-diffusion']
 
-    image = image.convert("RGB")
+    image = image.convert('RGB')
     image = resize_img(image, desired_width, desired_height, clamp_to_64=True)
     image = img_to_tensor(image, batch_size, context.device, context.half_precision, shift_range=True)
-    image = model.get_first_stage_encoding(model.encode_first_stage(image))  # move to latent space
+    image = model.get_first_stage_encoding(model.encode_first_stage(image)) # move to latent space
 
     if mask is None:
         return image, None
 
-    mask = mask.convert("RGB")
+    mask = mask.convert('RGB')
     mask = resize_img(mask, image.shape[3], image.shape[2])
     mask = ImageOps.invert(mask)
     mask = img_to_tensor(mask, batch_size, context.device, context.half_precision, unsqueeze=True)
 
     return image, mask
 
-
 def latent_samples_to_images(context: Context, samples):
-    model = context.models["stable-diffusion"]
+    model = context.models['stable-diffusion']
 
-    if context.half_precision and samples.dtype != torch.float16:
-        samples = samples.half()
+    if context.half_precision and samples.dtype != torch.float16: samples = samples.half()
 
     samples = model.decode_first_stage(samples)
     samples = torch.clamp((samples + 1.0) / 2.0, min=0.0, max=1.0)

--- a/sdkit/utils/latent_utils.py
+++ b/sdkit/utils/latent_utils.py
@@ -5,14 +5,22 @@ from einops import repeat, rearrange
 
 from sdkit import Context
 
-def img_to_tensor(img: Image, batch_size, device, half_precision: bool, shift_range=False, unsqueeze=False):
+
+def img_to_tensor(
+    img: Image,
+    batch_size,
+    device,
+    half_precision: bool,
+    shift_range=False,
+    unsqueeze=False,
+):
     if img is None:
         return None
 
     img = np.array(img).astype(np.float32) / 255.0
     img = img[None].transpose(0, 3, 1, 2)
     img = torch.from_numpy(img)
-    img = 2. * img - 1. if shift_range else img
+    img = 2.0 * img - 1.0 if shift_range else img
     img = img.to(device)
 
     if device != "cpu" and half_precision:
@@ -21,39 +29,56 @@ def img_to_tensor(img: Image, batch_size, device, half_precision: bool, shift_ra
     if unsqueeze:
         img = img[0][0].unsqueeze(0).repeat(4, 1, 1).unsqueeze(0)
 
-    img = repeat(img, '1 ... -> b ...', b=batch_size)
+    img = repeat(img, "1 ... -> b ...", b=batch_size)
 
     return img
 
-def get_image_latent_and_mask(context: Context, image: Image, mask: Image, desired_width, desired_height, batch_size):
+
+def get_image_latent_and_mask(
+    context: Context,
+    image: Image,
+    mask: Image,
+    desired_width,
+    desired_height,
+    batch_size,
+):
     """
     Assumes model is on the correct device
     """
     from .image_utils import resize_img
-    if image is None or 'stable-diffusion' not in context.models:
+
+    if image is None or "stable-diffusion" not in context.models:
         return None, None
 
-    model = context.models['stable-diffusion']
+    model = context.models["stable-diffusion"]
 
-    image = image.convert('RGB')
+    image = image.convert("RGB")
     image = resize_img(image, desired_width, desired_height, clamp_to_64=True)
-    image = img_to_tensor(image, batch_size, context.device, context.half_precision, shift_range=True)
-    image = model.get_first_stage_encoding(model.encode_first_stage(image)) # move to latent space
+    image = img_to_tensor(
+        image, batch_size, context.device, context.half_precision, shift_range=True
+    )
+    image = model.get_first_stage_encoding(
+        model.encode_first_stage(image)
+    )  # move to latent space
 
     if mask is None:
         return image, None
 
-    mask = mask.convert('RGB')
+    mask = mask.convert("RGB")
     mask = resize_img(mask, image.shape[3], image.shape[2])
     mask = ImageOps.invert(mask)
-    mask = img_to_tensor(mask, batch_size, context.device, context.half_precision, unsqueeze=True)
+    mask = img_to_tensor(
+        mask, batch_size, context.device, context.half_precision, unsqueeze=True
+    )
 
     return image, mask
 
-def latent_samples_to_images(context: Context, samples):
-    model = context.models['stable-diffusion']
 
-    if context.half_precision and samples.dtype != torch.float16: samples = samples.half()
+def latent_samples_to_images(context: Context, samples):
+    model = context.models["stable-diffusion"]
+
+    if context.half_precision and samples.dtype != torch.float16:
+        samples = samples.half()
 
     samples = model.decode_first_stage(samples)
     samples = torch.clamp((samples + 1.0) / 2.0, min=0.0, max=1.0)

--- a/sdkit/utils/latent_utils.py
+++ b/sdkit/utils/latent_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
+from einops import rearrange, repeat
 from PIL import Image, ImageOps
-from einops import repeat, rearrange
 
 from sdkit import Context
 

--- a/sdkit/utils/latent_utils.py
+++ b/sdkit/utils/latent_utils.py
@@ -54,12 +54,8 @@ def get_image_latent_and_mask(
 
     image = image.convert("RGB")
     image = resize_img(image, desired_width, desired_height, clamp_to_64=True)
-    image = img_to_tensor(
-        image, batch_size, context.device, context.half_precision, shift_range=True
-    )
-    image = model.get_first_stage_encoding(
-        model.encode_first_stage(image)
-    )  # move to latent space
+    image = img_to_tensor(image, batch_size, context.device, context.half_precision, shift_range=True)
+    image = model.get_first_stage_encoding(model.encode_first_stage(image))  # move to latent space
 
     if mask is None:
         return image, None
@@ -67,9 +63,7 @@ def get_image_latent_and_mask(
     mask = mask.convert("RGB")
     mask = resize_img(mask, image.shape[3], image.shape[2])
     mask = ImageOps.invert(mask)
-    mask = img_to_tensor(
-        mask, batch_size, context.device, context.half_precision, unsqueeze=True
-    )
+    mask = img_to_tensor(mask, batch_size, context.device, context.half_precision, unsqueeze=True)
 
     return image, mask
 

--- a/sdkit/utils/memory_utils.py
+++ b/sdkit/utils/memory_utils.py
@@ -9,19 +9,21 @@ from sdkit import Context
 tensor_ids_snapshot = None
 recorded_tensor_names = {}
 
+
 def gc(context: Context):
     collect()
-    if context.device == 'cpu':
+    if context.device == "cpu":
         return
 
     torch.cuda.empty_cache()
     torch.cuda.ipc_collect()
 
+
 def get_device_usage(device, log_info=False):
     cpu_used = psutil.cpu_percent()
     ram_used, ram_total = psutil.virtual_memory().used, psutil.virtual_memory().total
-    vram_free, vram_total = torch.cuda.mem_get_info(device) if device != 'cpu' else (0, 0)
-    vram_used = (vram_total - vram_free)
+    vram_free, vram_total = torch.cuda.mem_get_info(device) if device != "cpu" else (0, 0)
+    vram_used = vram_total - vram_free
 
     ram_used /= 1024**3
     ram_total /= 1024**3
@@ -30,95 +32,106 @@ def get_device_usage(device, log_info=False):
 
     if log_info:
         from sdkit.utils import log
-        msg = f'CPU utilization: {cpu_used:.1f}%, System RAM used: {ram_used:.1f} of {ram_total:.1f} GiB'
-        if device != 'cpu': msg += f', GPU RAM used ({device}): {vram_used:.1f} of {vram_total:.1f} GiB'
+
+        msg = f"CPU utilization: {cpu_used:.1f}%, System RAM used: {ram_used:.1f} of {ram_total:.1f} GiB"
+        if device != "cpu":
+            msg += f", GPU RAM used ({device}): {vram_used:.1f} of {vram_total:.1f} GiB"
         log.info(msg)
 
     return cpu_used, ram_used, ram_total, vram_used, vram_total
 
+
 def get_object_id(o):
-    '''
+    """
     Returns a more-readable object id, than the long number returned by the inbuilt `id()` function.
     Internally, this calls `id()` and converts the number to a base64 string.
-    '''
+    """
 
     obj_id = id(o)
-    obj_id = base64.b64encode(obj_id.to_bytes(8, 'big')).decode()
-    return obj_id.translate({43:None, 47:None, 61:None})[-8:]
+    obj_id = base64.b64encode(obj_id.to_bytes(8, "big")).decode()
+    return obj_id.translate({43: None, 47: None, 61: None})[-8:]
 
-def record_tensor_name(t, name='t', log_info=False):
-    '''
+
+def record_tensor_name(t, name="t", log_info=False):
+    """
     Records a name for the given tensor object. Helpful while investigating the source of memory leaks.
 
     For e.g. you can record variables from across the codebase, and see which one is leaking by calling
     `print_largest_tensors_in_memory()` or `take_memory_snapshot()` after calling `gc()` (for garbage-collection).
-    
+
     `print_largest_tensors_in_memory()` and `take_memory_snapshot()` print the recorded names for each tensor, if available.
-    '''
+    """
 
     obj_id = get_object_id(t)
     recorded_tensor_names[obj_id] = [] if obj_id not in recorded_tensor_names else recorded_tensor_names[obj_id]
     recorded_tensor_names[obj_id].append(name)
 
-    if log_info: print_tensor_info(t, name)
+    if log_info:
+        print_tensor_info(t, name)
 
-def print_tensor_info(t, name='t'):
-    'Prints a summary of the tensor, for e.g. its size, shape, data type, device etc.'
+
+def print_tensor_info(t, name="t"):
+    "Prints a summary of the tensor, for e.g. its size, shape, data type, device etc."
 
     from sdkit.utils import log
 
     obj_id = get_object_id(t)
-    obj_size = t.nelement() * t.element_size() / 1024**2 # MiB
-    log.info(f' {name} id: {obj_id}, size: {obj_size} MiB, shape: {t.shape}, requires_grad: {t.requires_grad}, type: {t.dtype}, device: {t.device}')
+    obj_size = t.nelement() * t.element_size() / 1024**2  # MiB
+    log.info(
+        f" {name} id: {obj_id}, size: {obj_size} MiB, shape: {t.shape}, requires_grad: {t.requires_grad}, type: {t.dtype}, device: {t.device}"
+    )
+
 
 def get_tensors_in_memory(device):
-    '''
+    """
     Returns the list of all the tensor objects in memory, on the given device.
     **Warning: Do not keep a reference to the returned list longer than necessary, since that will
     prevent garbage-collection of all the tensors in memory.**
-    '''
+    """
 
     device = torch.device(device) if isinstance(device, str) else device
     tensors = []
     objs_in_mem = get_objects()
     for obj in objs_in_mem:
         try:
-            if (torch.is_tensor(obj) or (hasattr(obj, 'data') and torch.is_tensor(obj.data))) and obj.device == device:
+            if (torch.is_tensor(obj) or (hasattr(obj, "data") and torch.is_tensor(obj.data))) and obj.device == device:
                 tensors.append(obj)
         except:
             pass
 
     return tensors
 
+
 def print_largest_tensors_in_memory(device, num=10):
-    '''
+    """
     Prints a list of the largest tensors in the given device. Choose the number of objects displayed with the `num` argument.
 
     Prints the recorded names for each tensor, if recorded using `record_tensor_name()`.
 
     See also: `take_memory_snapshot()` which is probably more useful for investigating memory leaks.
-    '''
+    """
 
     entries, total_mem = _get_tensor_entries(device)
     n = len(entries)
-    entries = entries[:min(num, n)]
+    entries = entries[: min(num, n)]
 
-    print(f'== {num} largest tensors on {device} ==')
+    print(f"== {num} largest tensors on {device} ==")
     print(_fmt_tensors_summary(entries))
-    print('---')
-    print(f'Total memory occupied on {device} by {n} tensors: {total_mem:.1f} MiB')
+    print("---")
+    print(f"Total memory occupied on {device} by {n} tensors: {total_mem:.1f} MiB")
+
 
 def take_memory_snapshot(device, print_snapshot=True):
-    '''
+    """
     Records and prints a list of new tensors (in the device) since the last snapshot (created by calling `take_memory_snapshot()`).
 
     Prints the recorded names for each tensor, if recorded using `record_tensor_name()`.
 
     See also: `print_largest_tensors_in_memory()`.
-    '''
+    """
     global tensor_ids_snapshot
 
-    is_first_snapshot = (tensor_ids_snapshot is None)
+    is_first_snapshot = tensor_ids_snapshot is None
     tensor_ids_snapshot = set() if is_first_snapshot else tensor_ids_snapshot
 
     # take the snapshot
@@ -132,22 +145,23 @@ def take_memory_snapshot(device, print_snapshot=True):
         return
 
     new_tensor_entries = [entry for entry in entries if entry[0] in new_tensor_ids]
-    new_tensors_total_mem = reduce(lambda sum, entry: sum + entry[1], new_tensor_entries, 0) # MiB
+    new_tensors_total_mem = reduce(lambda sum, entry: sum + entry[1], new_tensor_entries, 0)  # MiB
     print(new_tensors_total_mem)
     num_new_tensors = len(new_tensor_ids)
 
-    print(f'== {num_new_tensors} new tensors this snapshot on {device} ==')
+    print(f"== {num_new_tensors} new tensors this snapshot on {device} ==")
     print(_fmt_tensors_summary(new_tensor_entries))
-    print('---')
-    print(f'Total memory occupied on {device} by {len(entries)} tensors: {total_mem:.1f} MiB')
-    print(f'{num_new_tensors} new tensors added {new_tensors_total_mem:.1f} MiB this frame')
+    print("---")
+    print(f"Total memory occupied on {device} by {len(entries)} tensors: {total_mem:.1f} MiB")
+    print(f"{num_new_tensors} new tensors added {new_tensors_total_mem:.1f} MiB this frame")
+
 
 def _get_tensor_entries(device, sorted_by_size=True):
     entries = []
     tensors = get_tensors_in_memory(device)
     total_mem = 0
     for t in tensors:
-        size = t.nelement() * t.element_size() / 1024**2 # MiB
+        size = t.nelement() * t.element_size() / 1024**2  # MiB
         obj_id = get_object_id(t)
         entry = [obj_id, size, t.shape, len(get_referrers(t)), t.requires_grad, t.dtype]
         entries.append(entry)
@@ -155,15 +169,19 @@ def _get_tensor_entries(device, sorted_by_size=True):
 
     del tensors
 
-    if sorted_by_size: entries.sort(key=lambda x: x[0], reverse=True)
+    if sorted_by_size:
+        entries.sort(key=lambda x: x[0], reverse=True)
 
     return entries, total_mem
+
 
 def _fmt_tensors_summary(entries):
     summary = []
     for i, o in enumerate(entries):
         obj_id, size, shape, n_referrers, requires_grad, dtype = o
-        known_names = f' ({recorded_tensor_names[obj_id]})' if obj_id in recorded_tensor_names else ''
-        summary.append(f'{i+1}. Id: {obj_id}{known_names}, Size: {size:.1f} MiB, Shape: {shape}, Referrers: {n_referrers}, requires_grad: {requires_grad}, dtype: {dtype}')
+        known_names = f" ({recorded_tensor_names[obj_id]})" if obj_id in recorded_tensor_names else ""
+        summary.append(
+            f"{i+1}. Id: {obj_id}{known_names}, Size: {size:.1f} MiB, Shape: {shape}, Referrers: {n_referrers}, requires_grad: {requires_grad}, dtype: {dtype}"
+        )
 
-    return '\n'.join(summary)
+    return "\n".join(summary)

--- a/sdkit/utils/memory_utils.py
+++ b/sdkit/utils/memory_utils.py
@@ -1,30 +1,27 @@
+import torch
+import psutil
 import base64
 from functools import reduce
 from gc import collect, get_objects, get_referrers
-
-import psutil
-import torch
 
 from sdkit import Context
 
 tensor_ids_snapshot = None
 recorded_tensor_names = {}
 
-
 def gc(context: Context):
     collect()
-    if context.device == "cpu":
+    if context.device == 'cpu':
         return
 
     torch.cuda.empty_cache()
     torch.cuda.ipc_collect()
 
-
 def get_device_usage(device, log_info=False):
     cpu_used = psutil.cpu_percent()
     ram_used, ram_total = psutil.virtual_memory().used, psutil.virtual_memory().total
-    vram_free, vram_total = torch.cuda.mem_get_info(device) if device != "cpu" else (0, 0)
-    vram_used = vram_total - vram_free
+    vram_free, vram_total = torch.cuda.mem_get_info(device) if device != 'cpu' else (0, 0)
+    vram_used = (vram_total - vram_free)
 
     ram_used /= 1024**3
     ram_total /= 1024**3
@@ -33,113 +30,95 @@ def get_device_usage(device, log_info=False):
 
     if log_info:
         from sdkit.utils import log
-
-        msg = f"CPU utilization: {cpu_used:.1f}%, System RAM used: {ram_used:.1f} of {ram_total:.1f} GiB"
-        if device != "cpu":
-            msg += f", GPU RAM used ({device}): {vram_used:.1f} of {vram_total:.1f} GiB"
+        msg = f'CPU utilization: {cpu_used:.1f}%, System RAM used: {ram_used:.1f} of {ram_total:.1f} GiB'
+        if device != 'cpu': msg += f', GPU RAM used ({device}): {vram_used:.1f} of {vram_total:.1f} GiB'
         log.info(msg)
 
     return cpu_used, ram_used, ram_total, vram_used, vram_total
 
-
 def get_object_id(o):
-    """
-    Returns a more-readable object id, than the long number returned by
-    the inbuilt `id()` function. Internally, this calls `id()` and converts
-    the number to a base64 string.
-    """
+    '''
+    Returns a more-readable object id, than the long number returned by the inbuilt `id()` function.
+    Internally, this calls `id()` and converts the number to a base64 string.
+    '''
 
     obj_id = id(o)
-    obj_id = base64.b64encode(obj_id.to_bytes(8, "big")).decode()
-    return obj_id.translate({43: None, 47: None, 61: None})[-8:]
+    obj_id = base64.b64encode(obj_id.to_bytes(8, 'big')).decode()
+    return obj_id.translate({43:None, 47:None, 61:None})[-8:]
 
+def record_tensor_name(t, name='t', log_info=False):
+    '''
+    Records a name for the given tensor object. Helpful while investigating the source of memory leaks.
 
-def record_tensor_name(t, name="t", log_info=False):
-    """
-    Records a name for the given tensor object. Helpful while investigating
-    the source of memory leaks.
-
-    For e.g. you can record variables from across the codebase, and see
-    which one is leaking by calling `print_largest_tensors_in_memory()`
-    or `take_memory_snapshot()` after calling `gc()` (for garbage-collection).
-
-    `print_largest_tensors_in_memory()` and `take_memory_snapshot()`
-    print the recorded names for each tensor, if available.
-    """
+    For e.g. you can record variables from across the codebase, and see which one is leaking by calling
+    `print_largest_tensors_in_memory()` or `take_memory_snapshot()` after calling `gc()` (for garbage-collection).
+    
+    `print_largest_tensors_in_memory()` and `take_memory_snapshot()` print the recorded names for each tensor, if available.
+    '''
 
     obj_id = get_object_id(t)
     recorded_tensor_names[obj_id] = [] if obj_id not in recorded_tensor_names else recorded_tensor_names[obj_id]
     recorded_tensor_names[obj_id].append(name)
 
-    if log_info:
-        print_tensor_info(t, name)
+    if log_info: print_tensor_info(t, name)
 
-
-def print_tensor_info(t, name="t"):
-    "Prints a summary of the tensor, for e.g. its size, shape, data type, device etc."
+def print_tensor_info(t, name='t'):
+    'Prints a summary of the tensor, for e.g. its size, shape, data type, device etc.'
 
     from sdkit.utils import log
 
     obj_id = get_object_id(t)
-    obj_size = t.nelement() * t.element_size() / 1024**2  # MiB
-    log.info(
-        f" {name} id: {obj_id}, size: {obj_size} MiB, shape: {t.shape}, requires_grad:"
-        f" {t.requires_grad}, type: {t.dtype}, device: {t.device}"
-    )
-
+    obj_size = t.nelement() * t.element_size() / 1024**2 # MiB
+    log.info(f' {name} id: {obj_id}, size: {obj_size} MiB, shape: {t.shape}, requires_grad: {t.requires_grad}, type: {t.dtype}, device: {t.device}')
 
 def get_tensors_in_memory(device):
-    """
+    '''
     Returns the list of all the tensor objects in memory, on the given device.
     **Warning: Do not keep a reference to the returned list longer than necessary, since that will
     prevent garbage-collection of all the tensors in memory.**
-    """
+    '''
 
     device = torch.device(device) if isinstance(device, str) else device
     tensors = []
     objs_in_mem = get_objects()
     for obj in objs_in_mem:
         try:
-            if (torch.is_tensor(obj) or (hasattr(obj, "data") and torch.is_tensor(obj.data))) and obj.device == device:
+            if (torch.is_tensor(obj) or (hasattr(obj, 'data') and torch.is_tensor(obj.data))) and obj.device == device:
                 tensors.append(obj)
         except:
             pass
 
     return tensors
 
-
 def print_largest_tensors_in_memory(device, num=10):
-    """
-    Prints a list of the largest tensors in the given device.
-    Choose the number of objects displayed with the `num` argument.
+    '''
+    Prints a list of the largest tensors in the given device. Choose the number of objects displayed with the `num` argument.
 
     Prints the recorded names for each tensor, if recorded using `record_tensor_name()`.
 
     See also: `take_memory_snapshot()` which is probably more useful for investigating memory leaks.
-    """
+    '''
 
     entries, total_mem = _get_tensor_entries(device)
     n = len(entries)
-    entries = entries[: min(num, n)]
+    entries = entries[:min(num, n)]
 
-    print(f"== {num} largest tensors on {device} ==")
+    print(f'== {num} largest tensors on {device} ==')
     print(_fmt_tensors_summary(entries))
-    print("---")
-    print(f"Total memory occupied on {device} by {n} tensors: {total_mem:.1f} MiB")
-
+    print('---')
+    print(f'Total memory occupied on {device} by {n} tensors: {total_mem:.1f} MiB')
 
 def take_memory_snapshot(device, print_snapshot=True):
-    """
-    Records and prints a list of new tensors (in the device) since the last snapshot
-    (created by calling `take_memory_snapshot()`).
+    '''
+    Records and prints a list of new tensors (in the device) since the last snapshot (created by calling `take_memory_snapshot()`).
 
     Prints the recorded names for each tensor, if recorded using `record_tensor_name()`.
 
     See also: `print_largest_tensors_in_memory()`.
-    """
+    '''
     global tensor_ids_snapshot
 
-    is_first_snapshot = tensor_ids_snapshot is None
+    is_first_snapshot = (tensor_ids_snapshot is None)
     tensor_ids_snapshot = set() if is_first_snapshot else tensor_ids_snapshot
 
     # take the snapshot
@@ -153,23 +132,22 @@ def take_memory_snapshot(device, print_snapshot=True):
         return
 
     new_tensor_entries = [entry for entry in entries if entry[0] in new_tensor_ids]
-    new_tensors_total_mem = reduce(lambda sum, entry: sum + entry[1], new_tensor_entries, 0)  # MiB
+    new_tensors_total_mem = reduce(lambda sum, entry: sum + entry[1], new_tensor_entries, 0) # MiB
     print(new_tensors_total_mem)
     num_new_tensors = len(new_tensor_ids)
 
-    print(f"== {num_new_tensors} new tensors this snapshot on {device} ==")
+    print(f'== {num_new_tensors} new tensors this snapshot on {device} ==')
     print(_fmt_tensors_summary(new_tensor_entries))
-    print("---")
-    print(f"Total memory occupied on {device} by {len(entries)} tensors: {total_mem:.1f} MiB")
-    print(f"{num_new_tensors} new tensors added {new_tensors_total_mem:.1f} MiB this frame")
-
+    print('---')
+    print(f'Total memory occupied on {device} by {len(entries)} tensors: {total_mem:.1f} MiB')
+    print(f'{num_new_tensors} new tensors added {new_tensors_total_mem:.1f} MiB this frame')
 
 def _get_tensor_entries(device, sorted_by_size=True):
     entries = []
     tensors = get_tensors_in_memory(device)
     total_mem = 0
     for t in tensors:
-        size = t.nelement() * t.element_size() / 1024**2  # MiB
+        size = t.nelement() * t.element_size() / 1024**2 # MiB
         obj_id = get_object_id(t)
         entry = [obj_id, size, t.shape, len(get_referrers(t)), t.requires_grad, t.dtype]
         entries.append(entry)
@@ -177,20 +155,15 @@ def _get_tensor_entries(device, sorted_by_size=True):
 
     del tensors
 
-    if sorted_by_size:
-        entries.sort(key=lambda x: x[0], reverse=True)
+    if sorted_by_size: entries.sort(key=lambda x: x[0], reverse=True)
 
     return entries, total_mem
-
 
 def _fmt_tensors_summary(entries):
     summary = []
     for i, o in enumerate(entries):
         obj_id, size, shape, n_referrers, requires_grad, dtype = o
-        known_names = f" ({recorded_tensor_names[obj_id]})" if obj_id in recorded_tensor_names else ""
-        summary.append(
-            f"{i+1}. Id: {obj_id}{known_names}, Size: {size:.1f} MiB, Shape: {shape},"
-            f" Referrers: {n_referrers}, requires_grad: {requires_grad}, dtype: {dtype}"
-        )
+        known_names = f' ({recorded_tensor_names[obj_id]})' if obj_id in recorded_tensor_names else ''
+        summary.append(f'{i+1}. Id: {obj_id}{known_names}, Size: {size:.1f} MiB, Shape: {shape}, Referrers: {n_referrers}, requires_grad: {requires_grad}, dtype: {dtype}')
 
-    return "\n".join(summary)
+    return '\n'.join(summary)

--- a/sdkit/utils/memory_utils.py
+++ b/sdkit/utils/memory_utils.py
@@ -9,19 +9,23 @@ from sdkit import Context
 tensor_ids_snapshot = None
 recorded_tensor_names = {}
 
+
 def gc(context: Context):
     collect()
-    if context.device == 'cpu':
+    if context.device == "cpu":
         return
 
     torch.cuda.empty_cache()
     torch.cuda.ipc_collect()
 
+
 def get_device_usage(device, log_info=False):
     cpu_used = psutil.cpu_percent()
     ram_used, ram_total = psutil.virtual_memory().used, psutil.virtual_memory().total
-    vram_free, vram_total = torch.cuda.mem_get_info(device) if device != 'cpu' else (0, 0)
-    vram_used = (vram_total - vram_free)
+    vram_free, vram_total = (
+        torch.cuda.mem_get_info(device) if device != "cpu" else (0, 0)
+    )
+    vram_used = vram_total - vram_free
 
     ram_used /= 1024**3
     ram_total /= 1024**3
@@ -30,95 +34,111 @@ def get_device_usage(device, log_info=False):
 
     if log_info:
         from sdkit.utils import log
-        msg = f'CPU utilization: {cpu_used:.1f}%, System RAM used: {ram_used:.1f} of {ram_total:.1f} GiB'
-        if device != 'cpu': msg += f', GPU RAM used ({device}): {vram_used:.1f} of {vram_total:.1f} GiB'
+
+        msg = f"CPU utilization: {cpu_used:.1f}%, System RAM used: {ram_used:.1f} of {ram_total:.1f} GiB"
+        if device != "cpu":
+            msg += f", GPU RAM used ({device}): {vram_used:.1f} of {vram_total:.1f} GiB"
         log.info(msg)
 
     return cpu_used, ram_used, ram_total, vram_used, vram_total
 
+
 def get_object_id(o):
-    '''
+    """
     Returns a more-readable object id, than the long number returned by the inbuilt `id()` function.
     Internally, this calls `id()` and converts the number to a base64 string.
-    '''
+    """
 
     obj_id = id(o)
-    obj_id = base64.b64encode(obj_id.to_bytes(8, 'big')).decode()
-    return obj_id.translate({43:None, 47:None, 61:None})[-8:]
+    obj_id = base64.b64encode(obj_id.to_bytes(8, "big")).decode()
+    return obj_id.translate({43: None, 47: None, 61: None})[-8:]
 
-def record_tensor_name(t, name='t', log_info=False):
-    '''
+
+def record_tensor_name(t, name="t", log_info=False):
+    """
     Records a name for the given tensor object. Helpful while investigating the source of memory leaks.
 
     For e.g. you can record variables from across the codebase, and see which one is leaking by calling
     `print_largest_tensors_in_memory()` or `take_memory_snapshot()` after calling `gc()` (for garbage-collection).
-    
+
     `print_largest_tensors_in_memory()` and `take_memory_snapshot()` print the recorded names for each tensor, if available.
-    '''
+    """
 
     obj_id = get_object_id(t)
-    recorded_tensor_names[obj_id] = [] if obj_id not in recorded_tensor_names else recorded_tensor_names[obj_id]
+    recorded_tensor_names[obj_id] = (
+        [] if obj_id not in recorded_tensor_names else recorded_tensor_names[obj_id]
+    )
     recorded_tensor_names[obj_id].append(name)
 
-    if log_info: print_tensor_info(t, name)
+    if log_info:
+        print_tensor_info(t, name)
 
-def print_tensor_info(t, name='t'):
-    'Prints a summary of the tensor, for e.g. its size, shape, data type, device etc.'
+
+def print_tensor_info(t, name="t"):
+    "Prints a summary of the tensor, for e.g. its size, shape, data type, device etc."
 
     from sdkit.utils import log
 
     obj_id = get_object_id(t)
-    obj_size = t.nelement() * t.element_size() / 1024**2 # MiB
-    log.info(f' {name} id: {obj_id}, size: {obj_size} MiB, shape: {t.shape}, requires_grad: {t.requires_grad}, type: {t.dtype}, device: {t.device}')
+    obj_size = t.nelement() * t.element_size() / 1024**2  # MiB
+    log.info(
+        f" {name} id: {obj_id}, size: {obj_size} MiB, shape: {t.shape}, requires_grad: {t.requires_grad}, type: {t.dtype}, device: {t.device}"
+    )
+
 
 def get_tensors_in_memory(device):
-    '''
+    """
     Returns the list of all the tensor objects in memory, on the given device.
     **Warning: Do not keep a reference to the returned list longer than necessary, since that will
     prevent garbage-collection of all the tensors in memory.**
-    '''
+    """
 
     device = torch.device(device) if isinstance(device, str) else device
     tensors = []
     objs_in_mem = get_objects()
     for obj in objs_in_mem:
         try:
-            if (torch.is_tensor(obj) or (hasattr(obj, 'data') and torch.is_tensor(obj.data))) and obj.device == device:
+            if (
+                torch.is_tensor(obj)
+                or (hasattr(obj, "data") and torch.is_tensor(obj.data))
+            ) and obj.device == device:
                 tensors.append(obj)
         except:
             pass
 
     return tensors
 
+
 def print_largest_tensors_in_memory(device, num=10):
-    '''
+    """
     Prints a list of the largest tensors in the given device. Choose the number of objects displayed with the `num` argument.
 
     Prints the recorded names for each tensor, if recorded using `record_tensor_name()`.
 
     See also: `take_memory_snapshot()` which is probably more useful for investigating memory leaks.
-    '''
+    """
 
     entries, total_mem = _get_tensor_entries(device)
     n = len(entries)
-    entries = entries[:min(num, n)]
+    entries = entries[: min(num, n)]
 
-    print(f'== {num} largest tensors on {device} ==')
+    print(f"== {num} largest tensors on {device} ==")
     print(_fmt_tensors_summary(entries))
-    print('---')
-    print(f'Total memory occupied on {device} by {n} tensors: {total_mem:.1f} MiB')
+    print("---")
+    print(f"Total memory occupied on {device} by {n} tensors: {total_mem:.1f} MiB")
+
 
 def take_memory_snapshot(device, print_snapshot=True):
-    '''
+    """
     Records and prints a list of new tensors (in the device) since the last snapshot (created by calling `take_memory_snapshot()`).
 
     Prints the recorded names for each tensor, if recorded using `record_tensor_name()`.
 
     See also: `print_largest_tensors_in_memory()`.
-    '''
+    """
     global tensor_ids_snapshot
 
-    is_first_snapshot = (tensor_ids_snapshot is None)
+    is_first_snapshot = tensor_ids_snapshot is None
     tensor_ids_snapshot = set() if is_first_snapshot else tensor_ids_snapshot
 
     # take the snapshot
@@ -132,22 +152,29 @@ def take_memory_snapshot(device, print_snapshot=True):
         return
 
     new_tensor_entries = [entry for entry in entries if entry[0] in new_tensor_ids]
-    new_tensors_total_mem = reduce(lambda sum, entry: sum + entry[1], new_tensor_entries, 0) # MiB
+    new_tensors_total_mem = reduce(
+        lambda sum, entry: sum + entry[1], new_tensor_entries, 0
+    )  # MiB
     print(new_tensors_total_mem)
     num_new_tensors = len(new_tensor_ids)
 
-    print(f'== {num_new_tensors} new tensors this snapshot on {device} ==')
+    print(f"== {num_new_tensors} new tensors this snapshot on {device} ==")
     print(_fmt_tensors_summary(new_tensor_entries))
-    print('---')
-    print(f'Total memory occupied on {device} by {len(entries)} tensors: {total_mem:.1f} MiB')
-    print(f'{num_new_tensors} new tensors added {new_tensors_total_mem:.1f} MiB this frame')
+    print("---")
+    print(
+        f"Total memory occupied on {device} by {len(entries)} tensors: {total_mem:.1f} MiB"
+    )
+    print(
+        f"{num_new_tensors} new tensors added {new_tensors_total_mem:.1f} MiB this frame"
+    )
+
 
 def _get_tensor_entries(device, sorted_by_size=True):
     entries = []
     tensors = get_tensors_in_memory(device)
     total_mem = 0
     for t in tensors:
-        size = t.nelement() * t.element_size() / 1024**2 # MiB
+        size = t.nelement() * t.element_size() / 1024**2  # MiB
         obj_id = get_object_id(t)
         entry = [obj_id, size, t.shape, len(get_referrers(t)), t.requires_grad, t.dtype]
         entries.append(entry)
@@ -155,15 +182,23 @@ def _get_tensor_entries(device, sorted_by_size=True):
 
     del tensors
 
-    if sorted_by_size: entries.sort(key=lambda x: x[0], reverse=True)
+    if sorted_by_size:
+        entries.sort(key=lambda x: x[0], reverse=True)
 
     return entries, total_mem
+
 
 def _fmt_tensors_summary(entries):
     summary = []
     for i, o in enumerate(entries):
         obj_id, size, shape, n_referrers, requires_grad, dtype = o
-        known_names = f' ({recorded_tensor_names[obj_id]})' if obj_id in recorded_tensor_names else ''
-        summary.append(f'{i+1}. Id: {obj_id}{known_names}, Size: {size:.1f} MiB, Shape: {shape}, Referrers: {n_referrers}, requires_grad: {requires_grad}, dtype: {dtype}')
+        known_names = (
+            f" ({recorded_tensor_names[obj_id]})"
+            if obj_id in recorded_tensor_names
+            else ""
+        )
+        summary.append(
+            f"{i+1}. Id: {obj_id}{known_names}, Size: {size:.1f} MiB, Shape: {shape}, Referrers: {n_referrers}, requires_grad: {requires_grad}, dtype: {dtype}"
+        )
 
-    return '\n'.join(summary)
+    return "\n".join(summary)

--- a/sdkit/utils/memory_utils.py
+++ b/sdkit/utils/memory_utils.py
@@ -1,8 +1,9 @@
-import torch
-import psutil
 import base64
 from functools import reduce
 from gc import collect, get_objects, get_referrers
+
+import psutil
+import torch
 
 from sdkit import Context
 

--- a/tests/vram_frees_after_image_generation.py
+++ b/tests/vram_frees_after_image_generation.py
@@ -16,9 +16,7 @@ from sdkit.generate import generate_images
 from sdkit.models import load_model
 from sdkit.utils import get_device_usage, log
 
-DeviceUsage = namedtuple(
-    "DeviceUsage", ["cpu_used", "ram_used", "ram_total", "vram_used", "vram_total"]
-)
+DeviceUsage = namedtuple("DeviceUsage", ["cpu_used", "ram_used", "ram_total", "vram_used", "vram_total"])
 
 c = Context()
 
@@ -41,14 +39,17 @@ usage_after_render = DeviceUsage(*get_device_usage(c.device, log_info=True))
 
 print("")
 log.info(
-    f"VRAM trend: {usage_start.vram_used:.1f} (start) GiB to {usage_model_load.vram_used:.1f} GiB (before render) to {usage_after_render.vram_used:.1f} GiB (after render)"
+    f"VRAM trend: {usage_start.vram_used:.1f} (start) GiB to"
+    f" {usage_model_load.vram_used:.1f} GiB (before render) to"
+    f" {usage_after_render.vram_used:.1f} GiB (after render)"
 )
 print("")
 
 max_expected_vram = usage_model_load.vram_used + 0.3
 if usage_after_render.vram_used > max_expected_vram:
     log.error(
-        f"Test failed! VRAM after render was expected to be below {max_expected_vram:.1f} GiB, but was {usage_after_render.vram_used:.1f} GiB!"
+        "Test failed! VRAM after render was expected to be below"
+        f" {max_expected_vram:.1f} GiB, but was {usage_after_render.vram_used:.1f} GiB!"
     )
     exit(1)
 else:

--- a/tests/vram_frees_after_image_generation.py
+++ b/tests/vram_frees_after_image_generation.py
@@ -1,32 +1,27 @@
-import argparse
 import os
+import argparse
 from collections import namedtuple
 
 parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--models-dir",
-    type=str,
-    required=True,
-    help="Path to the directory containing the Stable Diffusion models",
-)
+parser.add_argument('--models-dir', type=str, required=True, help="Path to the directory containing the Stable Diffusion models")
 args = parser.parse_args()
 
 from sdkit import Context
-from sdkit.generate import generate_images
 from sdkit.models import load_model
-from sdkit.utils import get_device_usage, log
+from sdkit.generate import generate_images
+from sdkit.utils import log, get_device_usage
 
-DeviceUsage = namedtuple("DeviceUsage", ["cpu_used", "ram_used", "ram_total", "vram_used", "vram_total"])
+DeviceUsage = namedtuple('DeviceUsage', ['cpu_used', 'ram_used', 'ram_total', 'vram_used', 'vram_total'])
 
 c = Context()
 
-log.info("Starting..")
+log.info('Starting..')
 usage_start = DeviceUsage(*get_device_usage(c.device, log_info=True))
 
-c.model_paths["stable-diffusion"] = os.path.join(args.models_dir, "sd-v1-4.ckpt")
-load_model(c, "stable-diffusion")
+c.model_paths['stable-diffusion'] = os.path.join(args.models_dir, 'sd-v1-4.ckpt')
+load_model(c, 'stable-diffusion')
 
-log.info("Loaded the model..")
+log.info('Loaded the model..')
 usage_model_load = DeviceUsage(*get_device_usage(c.device, log_info=True))
 
 try:
@@ -34,23 +29,16 @@ try:
 except Exception as e:
     log.exception(e)
 
-log.info("Generated the image..")
+log.info('Generated the image..')
 usage_after_render = DeviceUsage(*get_device_usage(c.device, log_info=True))
 
-print("")
-log.info(
-    f"VRAM trend: {usage_start.vram_used:.1f} (start) GiB to"
-    f" {usage_model_load.vram_used:.1f} GiB (before render) to"
-    f" {usage_after_render.vram_used:.1f} GiB (after render)"
-)
-print("")
+print('')
+log.info(f'VRAM trend: {usage_start.vram_used:.1f} (start) GiB to {usage_model_load.vram_used:.1f} GiB (before render) to {usage_after_render.vram_used:.1f} GiB (after render)')
+print('')
 
 max_expected_vram = usage_model_load.vram_used + 0.3
 if usage_after_render.vram_used > max_expected_vram:
-    log.error(
-        "Test failed! VRAM after render was expected to be below"
-        f" {max_expected_vram:.1f} GiB, but was {usage_after_render.vram_used:.1f} GiB!"
-    )
+    log.error(f'Test failed! VRAM after render was expected to be below {max_expected_vram:.1f} GiB, but was {usage_after_render.vram_used:.1f} GiB!')
     exit(1)
 else:
-    log.info("Test passed!")
+    log.info('Test passed!')

--- a/tests/vram_frees_after_image_generation.py
+++ b/tests/vram_frees_after_image_generation.py
@@ -3,7 +3,9 @@ import argparse
 from collections import namedtuple
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--models-dir', type=str, required=True, help="Path to the directory containing the Stable Diffusion models")
+parser.add_argument(
+    "--models-dir", type=str, required=True, help="Path to the directory containing the Stable Diffusion models"
+)
 args = parser.parse_args()
 
 from sdkit import Context
@@ -11,17 +13,17 @@ from sdkit.models import load_model
 from sdkit.generate import generate_images
 from sdkit.utils import log, get_device_usage
 
-DeviceUsage = namedtuple('DeviceUsage', ['cpu_used', 'ram_used', 'ram_total', 'vram_used', 'vram_total'])
+DeviceUsage = namedtuple("DeviceUsage", ["cpu_used", "ram_used", "ram_total", "vram_used", "vram_total"])
 
 c = Context()
 
-log.info('Starting..')
+log.info("Starting..")
 usage_start = DeviceUsage(*get_device_usage(c.device, log_info=True))
 
-c.model_paths['stable-diffusion'] = os.path.join(args.models_dir, 'sd-v1-4.ckpt')
-load_model(c, 'stable-diffusion')
+c.model_paths["stable-diffusion"] = os.path.join(args.models_dir, "sd-v1-4.ckpt")
+load_model(c, "stable-diffusion")
 
-log.info('Loaded the model..')
+log.info("Loaded the model..")
 usage_model_load = DeviceUsage(*get_device_usage(c.device, log_info=True))
 
 try:
@@ -29,16 +31,20 @@ try:
 except Exception as e:
     log.exception(e)
 
-log.info('Generated the image..')
+log.info("Generated the image..")
 usage_after_render = DeviceUsage(*get_device_usage(c.device, log_info=True))
 
-print('')
-log.info(f'VRAM trend: {usage_start.vram_used:.1f} (start) GiB to {usage_model_load.vram_used:.1f} GiB (before render) to {usage_after_render.vram_used:.1f} GiB (after render)')
-print('')
+print("")
+log.info(
+    f"VRAM trend: {usage_start.vram_used:.1f} (start) GiB to {usage_model_load.vram_used:.1f} GiB (before render) to {usage_after_render.vram_used:.1f} GiB (after render)"
+)
+print("")
 
 max_expected_vram = usage_model_load.vram_used + 0.3
 if usage_after_render.vram_used > max_expected_vram:
-    log.error(f'Test failed! VRAM after render was expected to be below {max_expected_vram:.1f} GiB, but was {usage_after_render.vram_used:.1f} GiB!')
+    log.error(
+        f"Test failed! VRAM after render was expected to be below {max_expected_vram:.1f} GiB, but was {usage_after_render.vram_used:.1f} GiB!"
+    )
     exit(1)
 else:
-    log.info('Test passed!')
+    log.info("Test passed!")

--- a/tests/vram_frees_after_image_generation.py
+++ b/tests/vram_frees_after_image_generation.py
@@ -1,5 +1,5 @@
-import os
 import argparse
+import os
 from collections import namedtuple
 
 parser = argparse.ArgumentParser()
@@ -12,9 +12,9 @@ parser.add_argument(
 args = parser.parse_args()
 
 from sdkit import Context
-from sdkit.models import load_model
 from sdkit.generate import generate_images
-from sdkit.utils import log, get_device_usage
+from sdkit.models import load_model
+from sdkit.utils import get_device_usage, log
 
 DeviceUsage = namedtuple(
     "DeviceUsage", ["cpu_used", "ram_used", "ram_total", "vram_used", "vram_total"]

--- a/tests/vram_frees_after_image_generation.py
+++ b/tests/vram_frees_after_image_generation.py
@@ -1,5 +1,5 @@
-import os
 import argparse
+import os
 from collections import namedtuple
 
 parser = argparse.ArgumentParser()
@@ -9,9 +9,9 @@ parser.add_argument(
 args = parser.parse_args()
 
 from sdkit import Context
-from sdkit.models import load_model
 from sdkit.generate import generate_images
-from sdkit.utils import log, get_device_usage
+from sdkit.models import load_model
+from sdkit.utils import get_device_usage, log
 
 DeviceUsage = namedtuple("DeviceUsage", ["cpu_used", "ram_used", "ram_total", "vram_used", "vram_total"])
 

--- a/tests/vram_frees_after_image_generation.py
+++ b/tests/vram_frees_after_image_generation.py
@@ -3,7 +3,12 @@ import argparse
 from collections import namedtuple
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--models-dir', type=str, required=True, help="Path to the directory containing the Stable Diffusion models")
+parser.add_argument(
+    "--models-dir",
+    type=str,
+    required=True,
+    help="Path to the directory containing the Stable Diffusion models",
+)
 args = parser.parse_args()
 
 from sdkit import Context
@@ -11,17 +16,19 @@ from sdkit.models import load_model
 from sdkit.generate import generate_images
 from sdkit.utils import log, get_device_usage
 
-DeviceUsage = namedtuple('DeviceUsage', ['cpu_used', 'ram_used', 'ram_total', 'vram_used', 'vram_total'])
+DeviceUsage = namedtuple(
+    "DeviceUsage", ["cpu_used", "ram_used", "ram_total", "vram_used", "vram_total"]
+)
 
 c = Context()
 
-log.info('Starting..')
+log.info("Starting..")
 usage_start = DeviceUsage(*get_device_usage(c.device, log_info=True))
 
-c.model_paths['stable-diffusion'] = os.path.join(args.models_dir, 'sd-v1-4.ckpt')
-load_model(c, 'stable-diffusion')
+c.model_paths["stable-diffusion"] = os.path.join(args.models_dir, "sd-v1-4.ckpt")
+load_model(c, "stable-diffusion")
 
-log.info('Loaded the model..')
+log.info("Loaded the model..")
 usage_model_load = DeviceUsage(*get_device_usage(c.device, log_info=True))
 
 try:
@@ -29,16 +36,20 @@ try:
 except Exception as e:
     log.exception(e)
 
-log.info('Generated the image..')
+log.info("Generated the image..")
 usage_after_render = DeviceUsage(*get_device_usage(c.device, log_info=True))
 
-print('')
-log.info(f'VRAM trend: {usage_start.vram_used:.1f} (start) GiB to {usage_model_load.vram_used:.1f} GiB (before render) to {usage_after_render.vram_used:.1f} GiB (after render)')
-print('')
+print("")
+log.info(
+    f"VRAM trend: {usage_start.vram_used:.1f} (start) GiB to {usage_model_load.vram_used:.1f} GiB (before render) to {usage_after_render.vram_used:.1f} GiB (after render)"
+)
+print("")
 
 max_expected_vram = usage_model_load.vram_used + 0.3
 if usage_after_render.vram_used > max_expected_vram:
-    log.error(f'Test failed! VRAM after render was expected to be below {max_expected_vram:.1f} GiB, but was {usage_after_render.vram_used:.1f} GiB!')
+    log.error(
+        f"Test failed! VRAM after render was expected to be below {max_expected_vram:.1f} GiB, but was {usage_after_render.vram_used:.1f} GiB!"
+    )
     exit(1)
 else:
-    log.info('Test passed!')
+    log.info("Test passed!")


### PR DESCRIPTION
Re-opened previous PR as __init__.py files have been unintentionally overwritten. 

# What

The meat of the changes are really in the .github/workflow/py-lint.yml. All the python file have been modified either by runnning locally the following:

* `black tests scripts sdkit examples --line-length 120 --include="\.py"`
* `isort tests scripts sdkit examples --profile black`
* `autoflake --in-place --remove-all-unused-imports --remove-unused-variables --exclude=__init__.py --recursive .`
or following the recommendation of:

* `flake8 tests scripts sdkit examples --max-line-length 120 --extend-ignore=E203,E402,E501,E722,W391 --per-file-ignores=__init__.py:F401`

# Why

To get some code formatting standardisation.

Introducing a python linting & formatting stage using black, isort, flake8 and autoflake. On new PR the workflow will run through those tool to check the formatting and linting of the code. black, isort and autoflake should autoformat/lint the code and flake8 will conduct additional code formatting checks.