### PR TITLE
Improve webp support

### DIFF
--- a/sdkit/utils/image_utils.py
+++ b/sdkit/utils/image_utils.py
@@ -5,6 +5,7 @@ import cv2
 import numpy as np
 from PIL import Image
 from skimage import exposure
+import re
 
 
 # https://stackoverflow.com/a/61114178
@@ -15,10 +16,10 @@ def img_to_base64_str(img, output_format="PNG", output_quality=75):
 
 def img_to_buffer(img, output_format="PNG", output_quality=75):
     buffered = BytesIO()
-    if output_format.upper() == "JPEG":
-        img.save(buffered, format=output_format, quality=output_quality)
-    else:
+    if output_format.upper() == "PNG":
         img.save(buffered, format=output_format)
+    else:
+        img.save(buffered, format=output_format, quality=output_quality)
     buffered.seek(0)
     return buffered
 
@@ -26,14 +27,13 @@ def img_to_buffer(img, output_format="PNG", output_quality=75):
 def buffer_to_base64_str(buffered, output_format="PNG"):
     buffered.seek(0)
     img_byte = buffered.getvalue()
-    mime_type = "image/png" if output_format.lower() == "png" else "image/jpeg"
+    mime_type = f"image/{output_format.lower()}"
     img_str = f"data:{mime_type};base64," + base64.b64encode(img_byte).decode()
     return img_str
 
 
 def base64_str_to_buffer(img_str):
-    mime_type = "image/png" if img_str.startswith("data:image/png;") else "image/jpeg"
-    img_str = img_str[len(f"data:{mime_type};base64,") :]
+    img_str = re.sub(r"^data:image/[a-z]+;base64,", "", img_str)
     data = base64.b64decode(img_str)
     buffered = BytesIO(data)
     return buffered


### PR DESCRIPTION
None of these changes are needed to make WEBP outputs work (https://github.com/cmdr2/stable-diffusion-ui/pull/907). The changes do

* `file_utils.py save_dicts()` - This adds EXIF metadata  to the images when the metadata format is `embed`. According to https://developers.google.com/speed/webp/docs/riff_container EXIF data is supported
* `image_utils.py img_to_buffer()` - I think this controls the images shown in the UI after rending an image. This change should make your selected image quality apply to the images in the UI, instead of just the autosaved images
* `image_utils.py buffer_to_base64_str()` - This fixes the MIME type. Not sure where this is applied, since I didn't see any issues without this change
* `image_utils.py base64_str_to_buffer()` - The previous logic ended up working, because `jpeg` and `webp` happen to be the same length