### PR TITLE
Add support for MPS on Apple silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,9 +152,5 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+# JetBrains
+.idea/

--- a/sdkit/__init__.py
+++ b/sdkit/__init__.py
@@ -46,10 +46,10 @@ class Context(local):
     @device.setter
     def device(self, d):
         self._device = d
-        if d == "cpu":
+        if "cuda" not in d:
             from sdkit.utils import log
 
-            log.info("forcing full precision for device: cpu")
+            log.info(f"forcing full precision for device: {d}")
             self._half_precision = False
 
     @property
@@ -58,7 +58,9 @@ class Context(local):
 
     @half_precision.setter
     def half_precision(self, h):
-        self._half_precision = h if self._device != "cpu" else False
+        if h and "cuda" not in self._device:
+            raise RuntimeError(f"half precision is not supported on device: {self._device}")
+        self._half_precision = h
 
     @property
     def vram_usage_level(self):

--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -44,7 +44,7 @@ def generate_images(
         images = []
 
         seed_everything(seed)
-        precision_scope = torch.autocast if context.half_precision and context.device != "cpu" else nullcontext
+        precision_scope = torch.autocast if context.half_precision else nullcontext
 
         if "stable-diffusion" not in context.models:
             raise RuntimeError(

--- a/sdkit/models/model_loader/realesrgan.py
+++ b/sdkit/models/model_loader/realesrgan.py
@@ -21,12 +21,12 @@ def load_model(context: Context, **kwargs):
     model_to_use, _ = os.path.splitext(model_to_use)
     model_to_use = RealESRGAN_models[model_to_use]
 
-    half = context.half_precision if context.device != "cpu" else False
+    half = context.half_precision
     model = RealESRGANer(
         device=torch.device(context.device), scale=4, model_path=model_path, model=model_to_use, pre_pad=0, half=half
     )
-    if context.device == "cpu":
-        model.model.to("cpu")
+    if "cuda" not in context.device:
+        model.model.to(context.device)
 
     model.model.name = model_to_use
 

--- a/sdkit/utils/latent_utils.py
+++ b/sdkit/utils/latent_utils.py
@@ -35,7 +35,7 @@ def img_to_tensor(img: Image, batch_size, device, half_precision: bool, shift_ra
     img = 2.0 * img - 1.0 if shift_range else img
     img = img.to(device)
 
-    if device != "cpu" and half_precision:
+    if "cuda" in device and half_precision:
         img = img.half()
 
     if unsqueeze:

--- a/sdkit/utils/memory_utils.py
+++ b/sdkit/utils/memory_utils.py
@@ -13,17 +13,15 @@ recorded_tensor_names = {}
 
 def gc(context: Context):
     collect()
-    if context.device == "cpu":
-        return
-
-    torch.cuda.empty_cache()
-    torch.cuda.ipc_collect()
+    if "cuda" in context.device:
+        torch.cuda.empty_cache()
+        torch.cuda.ipc_collect()
 
 
 def get_device_usage(device, log_info=False):
     cpu_used = psutil.cpu_percent()
     ram_used, ram_total = psutil.virtual_memory().used, psutil.virtual_memory().total
-    vram_free, vram_total = torch.cuda.mem_get_info(device) if device != "cpu" else (0, 0)
+    vram_free, vram_total = torch.cuda.mem_get_info(device) if "cuda" in device else (0, 0)
     vram_used = vram_total - vram_free
 
     ram_used /= 1024**3
@@ -35,7 +33,7 @@ def get_device_usage(device, log_info=False):
         from sdkit.utils import log
 
         msg = f"CPU utilization: {cpu_used:.1f}%, System RAM used: {ram_used:.1f} of {ram_total:.1f} GiB"
-        if device != "cpu":
+        if "cuda" in device:
             msg += f", GPU RAM used ({device}): {vram_used:.1f} of {vram_total:.1f} GiB"
         log.info(msg)
 


### PR DESCRIPTION
breaking change:

* setting Context.half_precision now throws if half-precision is not supported on the device, instead of silently ignoring the request.

changes:

* changes logic from "is the device CPU" to "is the device not CUDA"
* enforce full precision for MPS
* removed redundant CPU checks