### PR TITLE
Allow saving lossless WEBPs

### DIFF
--- a/sdkit/models/model_loader/stable_diffusion/convert_from_ckpt.py
+++ b/sdkit/models/model_loader/stable_diffusion/convert_from_ckpt.py
@@ -327,19 +327,19 @@ def create_depth_diffusers_config(original_config, image_size: int):
     """
     depth_params = original_config.model.params.depth_stage_config.params
 
-    block_out_channels = [vae_params.ch * mult for mult in vae_params.ch_mult]
+    block_out_channels = [depth_params.ch * mult for mult in depth_params.ch_mult]
     down_block_types = ["DownEncoderBlock2D"] * len(block_out_channels)
     up_block_types = ["UpDecoderBlock2D"] * len(block_out_channels)
 
     config = dict(
         sample_size=image_size,
-        in_channels=vae_params.in_channels,
-        out_channels=vae_params.out_ch,
+        in_channels=depth_params.in_channels,
+        out_channels=depth_params.out_ch,
         down_block_types=tuple(down_block_types),
         up_block_types=tuple(up_block_types),
         block_out_channels=tuple(block_out_channels),
-        latent_channels=vae_params.z_channels,
-        layers_per_block=vae_params.num_res_blocks,
+        latent_channels=depth_params.z_channels,
+        layers_per_block=depth_params.num_res_blocks,
     )
     return config
 

--- a/sdkit/models/model_loader/vae.py
+++ b/sdkit/models/model_loader/vae.py
@@ -41,7 +41,7 @@ def load_model(context: Context, **kwargs):
             vae_config = create_vae_diffusers_config(original_config, image_size=image_size)
             vae_dict = convert_ldm_vae_checkpoint(vae, vae_config)
 
-            log.info(f"Loading diffusers vae")
+            log.info("Loading diffusers vae")
         else:
             vae_dict = {k: v for k, v in vae.items() if k[0:4] != "loss"}
 

--- a/sdkit/utils/file_utils.py
+++ b/sdkit/utils/file_utils.py
@@ -23,7 +23,14 @@ def save_tensor_file(data, path):
         return torch.save(data, path)
 
 
-def save_images(images: list, dir_path: str, file_name="image", output_format="JPEG", output_quality=75):
+def save_images(
+    images: list,
+    dir_path: str,
+    file_name="image",
+    output_format="JPEG",
+    output_quality=75,
+    output_lossless=False,
+):
     """
     * images: a list of of PIL.Image images to save
     * dir_path: the directory path where the images will be saved
@@ -33,6 +40,7 @@ def save_images(images: list, dir_path: str, file_name="image", output_format="J
           and the returned value will be used as the actual file name. e.g `def fn(i): return 'foo' + i`
     * output_format: 'JPEG', 'PNG', or 'WEBP'
     * output_quality: an integer between 0 and 100, used for JPEG and WEBP
+    * output_lossless: whether to save lossless images (WEBP only)
     """
     if dir_path is None:
         return
@@ -41,7 +49,8 @@ def save_images(images: list, dir_path: str, file_name="image", output_format="J
     for i, img in enumerate(images):
         actual_file_name = file_name(i) if callable(file_name) else f"{file_name}_{i}"
         path = os.path.join(dir_path, actual_file_name)
-        img.save(f"{path}.{output_format.lower()}", quality=output_quality)
+        output_lossless = output_lossless and output_format.lower() == "webp"
+        img.save(f"{path}.{output_format.lower()}", quality=output_quality, lossless=output_lossless)
 
 
 def save_dicts(entries: list, dir_path: str, file_name="data", output_format="txt", file_format=""):

--- a/sdkit/utils/image_utils.py
+++ b/sdkit/utils/image_utils.py
@@ -9,15 +9,17 @@ import re
 
 
 # https://stackoverflow.com/a/61114178
-def img_to_base64_str(img, output_format="PNG", output_quality=75):
-    buffered = img_to_buffer(img, output_format, output_quality=output_quality)
+def img_to_base64_str(img, output_format="PNG", output_quality=75, output_lossless=False):
+    buffered = img_to_buffer(img, output_format, output_quality=output_quality, output_lossless=output_lossless)
     return buffer_to_base64_str(buffered, output_format)
 
 
-def img_to_buffer(img, output_format="PNG", output_quality=75):
+def img_to_buffer(img, output_format="PNG", output_quality=75, output_lossless=False):
     buffered = BytesIO()
     if output_format.upper() == "PNG":
         img.save(buffered, format=output_format)
+    elif output_format.upper() == "WEBP":
+        img.save(buffered, format=output_format, quality=output_quality, lossless=output_lossless)
     else:
         img.save(buffered, format=output_format, quality=output_quality)
     buffered.seek(0)


### PR DESCRIPTION
This flag only applies to WEBPs. It is not the same as 100% quality.
A sample 1536x1536 image (2x upscaled) was:
* 382.3 KB for a 95% webp
* 598.3 KB for a 100% jpeg
* 563.9 KB for a 100% webp
* 2.9 MB for a png
* 2.1 MB for a lossless webp
The 100% quality was achieved by updating the UI to change the max from 95% to 100%.