### PR TITLE
fix dpm_stability, add dpmpp_2m (Diffusers)

### DIFF
--- a/sdkit/generate/sampler/diffusers_samplers.py
+++ b/sdkit/generate/sampler/diffusers_samplers.py
@@ -50,6 +50,8 @@ def make_samplers(ddim_scheduler):
         elif sampler_name in ("euler-ancestral", "euler_a"):
             scheduler = EulerAncestralDiscreteScheduler.from_config(ddim_scheduler.config)
         elif sampler_name in ("dpm", "dpm_solver_stability"):
+            scheduler = DPMSolverMultistepScheduler.from_config(ddim_scheduler.config, algorithm_type="dpmsolver")
+        elif sampler_name == "dpmpp_2m":
             scheduler = DPMSolverMultistepScheduler.from_config(ddim_scheduler.config)
         elif sampler_name == "dpm2":
             scheduler = KDPM2DiscreteScheduler.from_config(ddim_scheduler.config)


### PR DESCRIPTION
I've looked into Sampler implementation in diffusers and found the following:
DPMSolverMultistepScheduler uses algorithm_type="dpmsolver++" and solver_order=2 as default. Therefore the current implementation as "dpm_solver_stability" was in fact "dpmpp_2m" (DPM-Solver++ 2nd order multistep). Our old "dpm_solver_stability" uses the old algorithm_type="dpmsolver" with solver_order=2.

I also found kind of a solution for "dpmpp_2s", because diffusers also have DPMSolverSinglestepScheduler, but I couldn't find an ancestral implementation yet, that's why I haven't included it into this PR. 

Recreating our UNI-PC implementation seems nearly impossible. The original author hasn't implemented parts of his own code in diffusers, but I will look deeper into it, maybe I can find something I missed.

Btw. the change of parameters with scheduler.config.parameter after calling the class is not recognized by the scheduler as far as I could observe. It's better to pass the parameters directly like I did in this change. The reason I didn't change uni_pc was, that I got either black or distorted images with "our" config. Need to find the time to look into that more...