### PR TITLE
Don't reencode images to store exif data

### DIFF
--- a/sdkit/utils/file_utils.py
+++ b/sdkit/utils/file_utils.py
@@ -73,8 +73,8 @@ def save_dicts(entries: list, dir_path: str, file_name="data", output_format="tx
         path = os.path.join(dir_path, actual_file_name)
 
         if output_format.lower() == "embed":
-            targetImage = Image.open(f"{path}.{file_format.lower()}")
             if file_format.lower() == "png":
+                targetImage = Image.open(f"{path}.{file_format.lower()}")
                 embedded_metadata = PngInfo()
                 for key, val in metadata.items():
                     embedded_metadata.add_text(key, str(val))
@@ -85,7 +85,7 @@ def save_dicts(entries: list, dir_path: str, file_name="data", output_format="tx
                     "Exif": {piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(user_comment, encoding="unicode")}
                 }
                 exif_bytes = piexif.dump(exif_dict)
-                targetImage.save(f"{path}.{file_format.lower()}", exif=exif_bytes)
+                piexif.insert(exif_bytes, f"{path}.{file_format.lower()}")
         else:
             with open(f"{path}.{output_format.lower()}", "w", encoding="utf-8") as f:
                 if output_format.lower() == "txt":


### PR DESCRIPTION
Fixes https://github.com/cmdr2/stable-diffusion-ui/issues/1080

When embedding metadata, the current version of sdkit re-encodes the image, without obeying the encoder's quality setting. Using `piexif.insert()`, it's possible to embedd metadata without re-encoding the image. 

# Current version, JPG, Q=95%, no embedded metadata, 107KB
![a_photograph_of_an_astronaut_riding_a_horse_F7JKORE0](https://user-images.githubusercontent.com/5852422/229250260-933e2674-9884-4cb4-a0c1-9760b5a800ab.jpeg)

# Current version, JPG, Q=95, with embedded metadata, 42KB
![a_photograph_of_an_astronaut_riding_a_horse_F7JY7WT0](https://user-images.githubusercontent.com/5852422/229250446-0cff1571-55a1-46bc-abbc-2c376a6f6900.jpeg)

# New version, JPG, Q=95, with embedded metadata, 108KB
![a_photograph_of_an_astronaut_riding_a_horse_F7M6O8F0](https://user-images.githubusercontent.com/5852422/229250653-40dd2af3-f45f-41c9-9961-9b111546a717.jpeg)