### PR TITLE
Revert fix for legacy inpainting pipeline

### DIFF
--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -238,12 +238,6 @@ def make_with_diffusers(
     ):
         del cmd["width"]
         del cmd["height"]
-
-        if isinstance(operation_to_apply, StableDiffusionInpaintPipelineLegacy):
-            cmd["prompt"] = ""
-            # workaround for a bug in diffusers 0.14 and before. the actual prompt used is
-            # in the prompt_embeds field, but the legacy inpainting implementation still
-            # looks for the prompt field (pending PR: https://github.com/huggingface/diffusers/pull/2842)
     elif isinstance(operation_to_apply, StableDiffusionInpaintPipeline):
         del cmd["strength"]
 


### PR DESCRIPTION
Revert fix for legacy inpainting pipeline to resolve error:
"Error: Cannot forward both prompt: and prompt_embeds: tensor([[[-0.3879, 0.0287, -0.0504, ..., -0.4939, -0.3103, 0.0634], [-0.0220, -1.3945, 0.2969, ..., -0.9946, 1.1025, 0.4316], [-1.0068, -1.4854, 0.5654, ..., 0.3206, -1.1689, -0.6436], ..., [-0.1643, -0.2820, 0.3770, ..., -1.9668, 0.5664, 0.1243], [-0.1725, -0.2510, 0.3652, ..., -1.9678, 0.5537, 0.1084], [-0.1729, -0.2394, 0.3574, ..., -1.9629, 0.5518, 0.1042]]], device='cuda:0', dtype=torch.float16). Please make sure to only forward one of the two."
https://discord.com/channels/1014774730907209781/1021695193499582494/1098363181564444737

The old fix isn't needed with diffusers 0.15.1 and creates this error due to redundant prompt parameter.
