### PR TITLE
Fix F541 lint errors

### DIFF
--- a/sdkit/models/model_loader/lora.py
+++ b/sdkit/models/model_loader/lora.py
@@ -32,7 +32,7 @@ def apply_lora_model(context, alpha):
         _apply_lora(context, default_pipe, alpha)
     except:
         log.error(traceback.format_exc())
-        log.error(f"Could not apply LoRA!")
+        log.error("Could not apply LoRA!")
 
 
 # Temporarily dumped from https://github.com/huggingface/diffusers/blob/main/scripts/convert_lora_safetensor_to_diffusers.py

--- a/sdkit/models/model_loader/stable_diffusion/__init__.py
+++ b/sdkit/models/model_loader/stable_diffusion/__init__.py
@@ -234,7 +234,7 @@ def test_and_fix_precision(context, model, config, attn_precision):
             is_black_image = not images[0].getbbox()
 
         if is_black_image and attn_precision == "fp32" and context.half_precision:
-            log.info(f"trying full precision")
+            log.info("trying full precision")
             context.orig_half_precision = context.half_precision
             context.half_precision = False
             config.model.params.unet_config.params.use_fp16 = False


### PR DESCRIPTION
Fix:
```
sdkit/models/model_loader/lora.py:36:19: F541 f-string is missing placeholders
sdkit/models/model_loader/stable_diffusion/__init__.py:240:22: F541 f-string is missing placeholders
```
Does not fix the F821's in `convert_from_ckpt.py`, they seem to be "WIP"-related.