### PR TITLE
Add DDPM and DEIS samplers to Diffusers

### DIFF
--- a/sdkit/generate/sampler/diffusers_samplers.py
+++ b/sdkit/generate/sampler/diffusers_samplers.py
@@ -8,84 +8,67 @@ from diffusers import (
     LMSDiscreteScheduler,
     PNDMScheduler,
     UniPCMultistepScheduler,
+    DEISMultistepScheduler,
+    DDPMScheduler,
 )
 
 
-samplers = {
-    "plms": None,
-    "ddim": None,
-    "dpm_solver_stability": None,
-    "euler_a": None,
-    "euler": None,
-    "lms": None,
-    "heun": None,
-    "dpm2": None,
-    "dpm2_a": None,
-    "dpmpp_2s_a": None,
-    "dpmpp_2m": None,
-    "dpmpp_sde": None,
-    "dpm_fast": None,
-    "dpm_adaptive": None,
-    "unipc_snr": None,
-    "unipc_tu": None,
-    "unipc_tq": None,
-    "unipc_snr_2": None,
-    "unipc_tu_2": None,
+samplers = {}
+
+def _make_plms(ddim_scheduler):
+    config = dict(ddim_scheduler.config)
+    config["skip_prk_steps"] = True
+    return PNDMScheduler.from_config(ddim_scheduler.config)
+
+def _make_unipc(solver_type: str, solver_order: int, time_skip: str):
+    def callback(ddim_scheduler):
+        # logSNR and time_quadratic timeskips are not supported in diffusers
+        if (time_skip is not "time_uniform"):
+            return None
+
+        scheduler = UniPCMultistepScheduler.from_config(ddim_scheduler.config)
+        scheduler.config.solver_type = solver_type
+        scheduler.config.solver_order = solver_order
+        scheduler.config.lower_order_final = True
+        scheduler.config.thresholding = False
+        return scheduler
+    return callback
+
+_samplers_init = {
+    "plms": _make_plms,
+    "ddim": lambda ddim_scheduler: ddim_scheduler,
+    "dpm_solver_stability": lambda ddim_scheduler: DPMSolverMultistepScheduler.from_config(ddim_scheduler.config, algorithm_type="dpmsolver"),
+    "euler_a": lambda ddim_scheduler: EulerAncestralDiscreteScheduler.from_config(ddim_scheduler.config),
+    "euler": lambda ddim_scheduler: EulerDiscreteScheduler.from_config(ddim_scheduler.config),
+    "lms": lambda ddim_scheduler: LMSDiscreteScheduler.from_config(ddim_scheduler.config),
+    "heun": lambda ddim_scheduler: HeunDiscreteScheduler.from_config(ddim_scheduler.config),
+    "dpm2": lambda ddim_scheduler: KDPM2DiscreteScheduler.from_config(ddim_scheduler.config),
+    "dpm2_a": lambda ddim_scheduler: KDPM2AncestralDiscreteScheduler.from_config(ddim_scheduler.config),
+    "dpmpp_2s_a": None, # Not implemented in diffusers yet
+    "dpmpp_2m": lambda ddim_scheduler: DPMSolverMultistepScheduler.from_config(ddim_scheduler.config),
+    "dpmpp_sde": None, # Not implemented in diffusers yet
+    "dpm_fast": None, # Not implemented in diffusers yet
+    "dpm_adaptive": None, # Not implemented in diffusers yet
+    "ddpm": lambda ddim_scheduler: DDPMScheduler.from_config(ddim_scheduler.config),
+    "deis": lambda ddim_scheduler: DEISMultistepScheduler.from_config(ddim_scheduler.config),
+    "unipc_snr": _make_unipc("bh1", 3, "logSNR"), # logSNR is not supported in diffusers yet
+    "unipc_tu": _make_unipc("bh2", 2, "time_uniform"),
+    "unipc_tq": _make_unipc("bh1", 3, "time_quadratic"), # time_quadratic is not supported in diffusers yet
+    "unipc_snr_2": _make_unipc("vary_coeff", 1, "logSNR"), # logSNR is not supported in diffusers yet
+    "unipc_tu_2": _make_unipc("bh1", 3, "time_uniform"),
 }
 
+# plms alias
+_samplers_init["pndm"] = _samplers_init["plms"]
+# dpm_solver_stability alias
+_samplers_init["dpm"] = _samplers_init["dpm_solver_stability"]
+# euler_a alias
+_samplers_init["euler-ancestral"] = _samplers_init["euler_a"]
+
+for sampler_name in _samplers_init.keys():
+    samplers[sampler_name] = None
 
 def make_samplers(ddim_scheduler):
-    def make(sampler_name):
-        if sampler_name in ("pndm", "plms"):
-            config = dict(ddim_scheduler.config)
-            config["skip_prk_steps"] = True
-            scheduler = PNDMScheduler.from_config(ddim_scheduler.config)
-        elif sampler_name == "lms":
-            scheduler = LMSDiscreteScheduler.from_config(ddim_scheduler.config)
-        elif sampler_name == "heun":
-            scheduler = HeunDiscreteScheduler.from_config(ddim_scheduler.config)
-        elif sampler_name == "euler":
-            scheduler = EulerDiscreteScheduler.from_config(ddim_scheduler.config)
-        elif sampler_name in ("euler-ancestral", "euler_a"):
-            scheduler = EulerAncestralDiscreteScheduler.from_config(ddim_scheduler.config)
-        elif sampler_name in ("dpm", "dpm_solver_stability"):
-            scheduler = DPMSolverMultistepScheduler.from_config(ddim_scheduler.config, algorithm_type="dpmsolver")
-        elif sampler_name == "dpmpp_2m":
-            scheduler = DPMSolverMultistepScheduler.from_config(ddim_scheduler.config)
-        elif sampler_name == "dpm2":
-            scheduler = KDPM2DiscreteScheduler.from_config(ddim_scheduler.config)
-        elif sampler_name == "dpm2_a":
-            scheduler = KDPM2AncestralDiscreteScheduler.from_config(ddim_scheduler.config)
-        elif sampler_name.startswith("unipc_"):
-            scheduler = UniPCMultistepScheduler.from_config(ddim_scheduler.config)
-
-            if sampler_name == "unipc_snr":
-                scheduler.config.solver_type = "bh1"
-                scheduler.config.solver_order = 3
-            elif sampler_name == "unipc_tu":
-                scheduler.config.solver_type = "bh2"
-                scheduler.config.solver_order = 2
-            elif sampler_name == "unipc_tq":
-                scheduler.config.solver_type = "bh1"
-                scheduler.config.solver_order = 3
-            elif sampler_name == "unipc_snr_2":
-                scheduler.config.solver_type = "vary_coeff"
-                scheduler.config.solver_order = 1
-            elif sampler_name == "unipc_tu_2":
-                scheduler.config.solver_type = "bh1"
-                scheduler.config.solver_order = 3
-
-            scheduler.config.lower_order_final = True
-            scheduler.config.thresholding = False
-
-            if sampler_name in ("unipc_snr", "unipc_tq", "unipc_snr_2"):
-                scheduler = None  # logSNR and time_quadratic timeskips are not supported in diffusers
-        elif sampler_name == "ddim":
-            scheduler = ddim_scheduler
-        else:
-            scheduler = None
-
-        samplers[sampler_name] = scheduler
-
-    for sampler_name in samplers.keys():
-        make(sampler_name)
+    for sampler_name, sampler_factory in _samplers_init.items():
+        if sampler_factory is not None:
+            samplers[sampler_name] = sampler_factory(ddim_scheduler)


### PR DESCRIPTION
From testing at 30 steps DEIS has similar results as the non-ancestral samplers, while DDPM gives completely different results than other samplers
https://huggingface.co/docs/diffusers/api/schedulers/ddpm
https://huggingface.co/docs/diffusers/api/schedulers/deis

The samplers also work in img2img

Based on the class name `deis_2m` might be a better name than `deis`

Also refactored the code so that sampler names are only defined once

I did all of the other samplers in diffusers. These were the results:

* https://huggingface.co/docs/diffusers/api/schedulers/ddim_inverse - This only generated random noise
* https://huggingface.co/docs/diffusers/api/schedulers/ipndm - This only generated random noise
* https://huggingface.co/docs/diffusers/api/schedulers/repaint - This errors with `step() missing 2 required positional arguments: 'original_image' and 'mask'` when generating images
* https://huggingface.co/docs/diffusers/api/schedulers/singlestep_dpm_solver - I thought it might have been `dpmpp_2s_a` but it ended up being just `dpmpp_2s`. The results were very similar to `dpmpp_2m` so I didn't add it
* https://huggingface.co/docs/diffusers/api/schedulers/stochastic_karras_ve - This errors with `'ScoreSdeVeScheduler' object has no attribute 'step'` when generating images
* https://huggingface.co/docs/diffusers/api/schedulers/vq_diffusion - This errors with `__init__() missing 1 required positional argument: 'num_vec_classes'` when loading it with `VQDiffusionScheduler.from_config(ddim_scheduler.config)`