### PR TITLE
Initial support for DirectML (AMD on Windows) and TensorRT (CUDA-only).

### DIFF
--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -317,6 +317,11 @@ def make_with_diffusers(
     log.info("Done parsing the prompt")
     # --------------------------------------------------------------------------------------------------
 
+    # create TensorRT buffers, if necessary
+    if hasattr(operation_to_apply.unet, "_allocate_trt_buffers"):
+        dtype = torch.float16 if context.half_precision else torch.float32
+        operation_to_apply.unet._allocate_trt_buffers(operation_to_apply, context.device, dtype, width, height)
+
     # apply
     log.info(f"applying: {operation_to_apply}")
     log.info(f"Running on diffusers: {cmd}")

--- a/sdkit/models/model_loader/stable_diffusion/__init__.py
+++ b/sdkit/models/model_loader/stable_diffusion/__init__.py
@@ -23,7 +23,9 @@ from sdkit.utils import (
 tr_logging.set_verbosity_error()  # suppress unnecessary logging
 
 
-def load_model(context: Context, scan_model=True, check_for_config_with_same_name=True, **kwargs):
+def load_model(
+    context: Context, scan_model=True, check_for_config_with_same_name=True, convert_to_tensorrt=False, **kwargs
+):
     from sdkit.models import scan_model as scan_model_fn
 
     from . import optimizations
@@ -48,7 +50,7 @@ def load_model(context: Context, scan_model=True, check_for_config_with_same_nam
             sd_v1_4_info = get_model_info_from_db(model_type="stable-diffusion", model_id="1.4")
             config_file_path = resolve_model_config_file_path(sd_v1_4_info, model_path)
 
-        return load_diffusers_model(context, model_path, config_file_path)
+        return load_diffusers_model(context, model_path, config_file_path, convert_to_tensorrt)
 
     # load the model file
     sd = load_tensor_file(model_path)
@@ -112,7 +114,7 @@ def unload_model(context: Context, **kwargs):
     context.module_in_gpu = None  # don't keep a dangling reference, prevents gc
 
 
-def load_diffusers_model(context: Context, model_path, config_file_path):
+def load_diffusers_model(context: Context, model_path, config_file_path, convert_to_tensorrt):
     import torch
     from diffusers import (
         StableDiffusionImg2ImgPipeline,
@@ -120,9 +122,10 @@ def load_diffusers_model(context: Context, model_path, config_file_path):
         StableDiffusionInpaintPipelineLegacy,
     )
     from compel import Compel
+    import platform
 
     from sdkit.generate.sampler import diffusers_samplers
-    from sdkit.utils import gc
+    from sdkit.utils import gc, has_amd_gpu
 
     from .convert_from_ckpt import download_from_original_stable_diffusion_ckpt
     from . import diffusers_bugfixes  # required for applying the temp patches until diffusers 0.18 releases
@@ -159,6 +162,40 @@ def load_diffusers_model(context: Context, model_path, config_file_path):
     default_pipe.requires_safety_checker = False
     default_pipe.safety_checker = None
 
+    # optimize for TRT or DirectML (AMD on Windows)
+    model_component, _ = os.path.splitext(model_path)
+    unet_trt_path = model_component + ".unet.trt"
+    unet_onnx_path = model_component + ".unet.onnx"
+
+    use_directml = platform.system() == "Windows" and has_amd_gpu()
+    try:
+        from importlib.metadata import version
+
+        version("onnxruntime-directml")  # check if this is installed
+    except:
+        use_directml = False
+
+    if "cuda" not in context.device:
+        convert_to_tensorrt = False
+
+    if use_directml and (not os.path.exists(unet_onnx_path) or os.stat(unet_onnx_path).st_size == 0):
+        from sdkit.utils import gc, convert_pipeline_unet_to_onnx
+
+        log.info("Converting UNet to ONNX to run on AMD on Windows..")
+        convert_pipeline_unet_to_onnx(default_pipe, unet_onnx_path, fp16=False)  # on cpu, so fp32
+        log.info("Converted UNet to ONNX to run on AMD on Windows!")
+    elif convert_to_tensorrt and (not os.path.exists(unet_trt_path) or os.stat(unet_trt_path).st_size == 0):
+        from sdkit.utils import gc, convert_pipeline_unet_to_tensorrt
+
+        default_pipe = default_pipe.to(context.device, torch.float16 if context.half_precision else torch.float32)
+
+        log.info("Converting UNet to TensorRT for acceleration..")
+        convert_pipeline_unet_to_tensorrt(default_pipe, unet_trt_path, fp16=context.half_precision)
+        log.info("Converted UNet to TensorRT for acceleration!")
+
+        default_pipe = default_pipe.to("cpu", torch.float32)
+
+    # keep the VAE for future use (maybe use copy.deepcopy() instead of a file)
     save_tensor_file(default_pipe.vae.state_dict(), os.path.join(tempfile.gettempdir(), "sd-base-vae.safetensors"))
 
     if context.vram_usage_level == "low" and "cuda" in context.device:
@@ -194,6 +231,18 @@ def load_diffusers_model(context: Context, model_path, config_file_path):
         use_penultimate_clip_layer=context.clip_skip,
         device=context.device,
     )
+
+    # load the TensorRT or DirectML unet, if present
+    if use_directml and os.path.exists(unet_onnx_path) and os.stat(unet_onnx_path).st_size > 0:
+        from .accelerators import apply_directml_unet
+
+        apply_directml_unet(default_pipe, unet_onnx_path)
+        log.info("Using DirectML accelerated UNet")
+    elif os.path.exists(unet_trt_path) and os.stat(unet_trt_path).st_size > 0:
+        from .accelerators import apply_tensorrt_unet
+
+        apply_tensorrt_unet(default_pipe, unet_trt_path)
+        log.info("Using TensorRT accelerated UNet")
 
     # make samplers
     diffusers_samplers.make_samplers(context, default_pipe.scheduler)

--- a/sdkit/models/model_loader/stable_diffusion/accelerators.py
+++ b/sdkit/models/model_loader/stable_diffusion/accelerators.py
@@ -1,0 +1,144 @@
+import torch
+from dataclasses import dataclass
+import numpy as np
+
+"""
+Current issues:
+1. TRT is working only with fp32
+
+2. TRT goes out of memory when converting larger image ranges. Maybe try converting after switching to "balanced"?
+
+3. set CUDA_MODULE_LOADING=LAZY
+
+4. LoRA
+ > No clear approach for DirectML
+ > TRT: https://github.com/NVIDIA/TensorRT/blob/release/8.6/demo/Diffusion/utilities.py#L90
+ > Currently it takes an entire different ONNX file and transfers their weights. One can modify it to target specifically the KQV part of the network for LORAs instead.
+
+5. TRT performance is pretty restricted to a single image size
+"""
+
+
+def apply_directml_unet(pipeline, onnx_path):
+    unet_dml = UnetDirectML(onnx_path)
+
+    pipeline.unet.forward = unet_dml.forward
+
+
+def apply_tensorrt_unet(pipeline, trt_path):
+    unet_trt = UnetTRT(trt_path)
+
+    pipeline.unet.forward = unet_trt.forward
+
+    setattr(pipeline.unet, "_allocate_trt_buffers", unet_trt.allocate_buffers)
+
+
+@dataclass
+class UnetResult:
+    sample: torch.FloatTensor = None
+
+
+class UnetDirectML:
+    def __init__(self, onnx_path):
+        from diffusers.pipelines.onnx_utils import OnnxRuntimeModel
+        import onnxruntime as ort
+
+        # batch_size = 1
+
+        # these are supposed to make things faster, but don't seem to make a difference for me
+        sess_options = ort.SessionOptions()
+        sess_options.enable_mem_pattern = False
+        # sess_options.add_free_dimension_override_by_name("sample_batch", batch_size * 2)
+        # sess_options.add_free_dimension_override_by_name("sample_channels", 4)
+        # sess_options.add_free_dimension_override_by_name("sample_height", 64)
+        # sess_options.add_free_dimension_override_by_name("sample_width", 64)
+        # sess_options.add_free_dimension_override_by_name("timestep_batch", batch_size * 2)
+        # sess_options.add_free_dimension_override_by_name("encoder_hidden_states_batch", batch_size * 2)
+        # sess_options.add_free_dimension_override_by_name("encoder_hidden_states_sequence", 77)
+
+        self.unet_dml = OnnxRuntimeModel(
+            model=OnnxRuntimeModel.load_model(onnx_path, "DmlExecutionProvider", sess_options=sess_options)
+        )
+
+    def forward(self, sample, timestep, encoder_hidden_states, **kwargs):
+        from diffusers.pipelines.onnx_utils import ORT_TO_NP_TYPE
+
+        device = sample.device
+
+        timestep_dtype = next(
+            (input.type for input in self.unet_dml.model.get_inputs() if input.name == "timestep"), "tensor(float)"
+        )
+        timestep_dtype = ORT_TO_NP_TYPE[timestep_dtype]
+
+        input = {
+            "sample": sample.cpu().numpy(),
+            "timestep": np.array([timestep.cpu()], dtype=timestep_dtype),
+            "encoder_hidden_states": encoder_hidden_states.cpu().numpy(),
+        }
+
+        sample = self.unet_dml(**input)[0]
+        sample = torch.from_numpy(sample).to(device)
+        return UnetResult(sample)
+
+
+class UnetTRT:
+    def __init__(self, engine_path):
+        import tensorrt as trt
+
+        TRT_LOGGER = trt.Logger(trt.Logger.INFO)
+
+        trt.init_libnvinfer_plugins(None, "")
+        with open(engine_path, "rb") as f, trt.Runtime(TRT_LOGGER) as runtime:
+            self.engine = runtime.deserialize_cuda_engine(f.read())
+
+        self.trt_context = self.engine.create_execution_context()
+        self.tensors = {}
+
+    def allocate_buffers(self, pipeline, device, dtype, width=512, height=512):
+        "Call this once before an image is generated, not per sample"
+
+        unet_in_channels = pipeline.unet.config.in_channels
+        num_tokens = pipeline.text_encoder.config.max_position_embeddings
+        text_hidden_size = pipeline.text_encoder.config.hidden_size
+
+        self.tensors.clear()
+
+        shape_dict = {
+            "sample": (2, unet_in_channels, width // 8, height // 8),
+            "encoder_hidden_states": (2, num_tokens, text_hidden_size),
+            "timestep": (2,),
+        }
+        for i, binding in enumerate(self.engine):
+            if binding in shape_dict:
+                shape = shape_dict[binding]
+            else:
+                shape = self.engine.get_binding_shape(binding)
+
+            if binding == "out_sample":
+                shape = (2, 4, width // 8, height // 8)
+
+            if self.engine.binding_is_input(binding):
+                self.trt_context.set_binding_shape(i, shape)
+
+            self.tensors[binding] = torch.empty(tuple(shape), dtype=dtype, device=device)
+
+    def forward(self, sample, timestep, encoder_hidden_states, **kwargs):
+        from polygraphy import cuda
+
+        feed_dict = {
+            "sample": sample,
+            "timestep": timestep,
+            "encoder_hidden_states": encoder_hidden_states,
+        }
+        stream = cuda.Stream()
+
+        for name, tensor in feed_dict.items():
+            self.tensors[name].copy_(tensor)
+
+        for name, tensor in self.tensors.items():
+            self.trt_context.set_tensor_address(name, tensor.data_ptr())
+
+        if not self.trt_context.execute_async_v3(stream_handle=stream.ptr):
+            raise RuntimeError("Inference failed!")
+
+        return UnetResult(sample=self.tensors["out_sample"])

--- a/sdkit/utils/__init__.py
+++ b/sdkit/utils/__init__.py
@@ -35,3 +35,8 @@ from .memory_utils import (
     record_tensor_name,
     take_memory_snapshot,
 )
+from .convert_model_utils import (
+    convert_pipeline_unet_to_onnx,
+    convert_pipeline_unet_to_tensorrt,
+)
+from .device_utils import has_amd_gpu

--- a/sdkit/utils/convert_model_utils.py
+++ b/sdkit/utils/convert_model_utils.py
@@ -1,0 +1,171 @@
+import os
+import shutil
+from packaging import version
+import warnings
+
+
+def convert_pipeline_unet_to_onnx(pipeline, save_path, opset=17, fp16: bool = False):
+    import torch
+    import onnx
+    from torch.jit import TracerWarning
+
+    warnings.filterwarnings(
+        "ignore",
+        category=TracerWarning,
+        message="Converting a tensor to a Python boolean might cause the trace to be incorrect",
+    )
+    warnings.filterwarnings(
+        "ignore",
+        category=UserWarning,
+        message="The shape inference of prim::Constant type is missing",
+    )
+
+    unet_in_channels = pipeline.unet.config.in_channels
+    unet_sample_size = pipeline.unet.config.sample_size
+    num_tokens = pipeline.text_encoder.config.max_position_embeddings
+    text_hidden_size = pipeline.text_encoder.config.hidden_size
+
+    orig_device = pipeline.device
+    orig_dtype = pipeline.unet.dtype
+
+    _dtype = torch.float16 if fp16 else torch.float32
+    _device = pipeline.device if fp16 else "cpu"
+    pipeline = pipeline.to(_device, torch_dtype=_dtype)
+
+    tmp_dir = save_path + "_"  # collect the individual weights here
+    if os.path.exists(tmp_dir):
+        shutil.rmtree(tmp_dir)
+    os.mkdir(tmp_dir)
+    tmp_model_path = os.path.join(tmp_dir, "model.onnx")
+
+    model_name, _ = os.path.splitext(save_path)
+    model_name = os.path.basename(model_name)
+
+    onnx_export(
+        pipeline.unet,
+        model_args=(
+            torch.randn(2, unet_in_channels, unet_sample_size, unet_sample_size).to(device=_device, dtype=_dtype),
+            torch.randn(2).to(device=_device, dtype=_dtype),
+            torch.randn(2, num_tokens, text_hidden_size).to(device=_device, dtype=_dtype),
+            False,
+        ),
+        output_path=tmp_model_path,
+        ordered_input_names=["sample", "timestep", "encoder_hidden_states", "return_dict"],
+        output_names=["out_sample"],  # has to be different from "sample" for correct tracing
+        dynamic_axes={
+            "sample": {0: "batch", 1: "channels", 2: "height", 3: "width"},
+            "timestep": {0: "batch"},
+            "encoder_hidden_states": {0: "batch", 1: "sequence"},
+        },
+        opset=opset,
+        use_external_data_format=True,  # UNet is > 2GB, so the weights need to be split
+    )
+
+    unet = onnx.load(tmp_model_path)
+    shutil.rmtree(tmp_dir)
+    # collate external tensor files into one
+    onnx.save_model(
+        unet,
+        save_path,
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=model_name + ".onnx_weights.pb",
+        convert_attribute=False,
+    )
+
+    pipeline = pipeline.to(orig_device, torch_dtype=orig_dtype)
+
+
+def onnx_export(
+    model,
+    model_args: tuple,
+    output_path,
+    ordered_input_names,
+    output_names,
+    dynamic_axes,
+    opset,
+    use_external_data_format=False,
+):
+    import torch
+
+    kwargs = {
+        "input_names": ordered_input_names,
+        "output_names": output_names,
+        "dynamic_axes": dynamic_axes,
+        "do_constant_folding": True,
+        "use_external_data_format": use_external_data_format,
+        "enable_onnx_checker": True,
+        "opset_version": opset,
+    }
+
+    # PyTorch deprecated the `enable_onnx_checker` and `use_external_data_format` arguments in v1.11,
+    # so we check the torch version for backwards compatibility
+    is_torch_higher_than_1_11 = version.parse(version.parse(torch.__version__).base_version) > version.parse("1.11")
+    if is_torch_higher_than_1_11:
+        del kwargs["use_external_data_format"]
+        del kwargs["enable_onnx_checker"]
+
+    torch.onnx.export(model, model_args, output_path, **kwargs)
+
+
+def convert_onnx_unet_to_tensorrt(pipeline, onnx_path, save_path):
+    import tensorrt as trt
+
+    TRT_LOGGER = trt.Logger(trt.Logger.INFO)
+
+    batch_size = 1
+    unet_in_channels = pipeline.unet.config.in_channels
+    unet_sample_size = pipeline.unet.config.sample_size
+    num_tokens = pipeline.text_encoder.config.max_position_embeddings
+    text_hidden_size = pipeline.text_encoder.config.hidden_size
+
+    TRT_BUILDER = trt.Builder(TRT_LOGGER)
+    network = TRT_BUILDER.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
+    onnx_parser = trt.OnnxParser(network, TRT_LOGGER)
+    parse_success = onnx_parser.parse_from_file(onnx_path)
+
+    for idx in range(onnx_parser.num_errors):
+        print(onnx_parser.get_error(idx))
+    if not parse_success:
+        raise RuntimeError("ONNX model parsing failed")
+
+    config = TRT_BUILDER.create_builder_config()
+    profile = TRT_BUILDER.create_optimization_profile()
+
+    min_shape = {
+        "sample": (batch_size, unet_in_channels, unet_sample_size, unet_sample_size),
+        "encoder_hidden_states": (batch_size, num_tokens, text_hidden_size),
+        "timestep": (batch_size,),
+    }
+    max_shape = {
+        "sample": (batch_size * 2, unet_in_channels, unet_sample_size, unet_sample_size),
+        "encoder_hidden_states": (batch_size * 2, num_tokens, text_hidden_size),
+        "timestep": (batch_size * 2,),
+    }
+
+    for name in min_shape.keys():
+        profile.set_shape(name, min_shape[name], min_shape[name], max_shape[name])
+
+    config.add_optimization_profile(profile)
+
+    # config.max_workspace_size = 4096 * (1 << 20)
+    config.set_flag(trt.BuilderFlag.FP16)
+    serialized_engine = TRT_BUILDER.build_serialized_network(network, config)
+
+    ## save TRT engine
+    with open(save_path, "wb") as f:
+        f.write(serialized_engine)
+    print(f"TRT Engine saved to {save_path}")
+
+
+def convert_pipeline_unet_to_tensorrt(pipeline, save_path, opset=17, fp16: bool = False):
+    onnx_path = save_path + ".onnx"
+
+    if not os.path.exists(onnx_path) or os.stat(onnx_path).st_size == 0:
+        print("Making intermediate ONNX..")
+        convert_pipeline_unet_to_onnx(pipeline, onnx_path, opset, fp16=False)
+
+    if not os.path.exists(save_path) or os.stat(save_path).st_size == 0:
+        print("Converting intermediate ONNX to TensorRT..")
+        convert_onnx_unet_to_tensorrt(pipeline, onnx_path, save_path)
+        # os.remove(onnx_path)

--- a/sdkit/utils/device_utils.py
+++ b/sdkit/utils/device_utils.py
@@ -1,0 +1,20 @@
+import platform
+import subprocess
+
+
+def has_amd_gpu():
+    os_name = platform.system()
+    try:
+        if os_name == "Windows":
+            res = subprocess.run("wmic path win32_VideoController get name".split(" "), stdout=subprocess.PIPE)
+            res = res.stdout.decode("utf-8")
+            return "AMD" in res and "Radeon" in res
+        elif os_name == "Linux":
+            with open("/proc/bus/pci/devices", "r") as f:
+                device_info = f.read()
+
+            return "amdgpu" in device_info and "nvidia" not in device_info
+    except:
+        return False
+
+    return False


### PR DESCRIPTION
Not enabled by default. Requires `onnxruntime-directml` installed (via pip) to enable the AMD/Windows code path.

TensorRT's installation process is significantly more complex, and will be addressed in a separate PR.

Current limitations:
a) No LoRA,
b) TensorRT needs fp32
c) TensorRT goes out-of-memory when converting larger images
d) TensorRT consumes a lot of VRAM during image generation
e) TensorRT performance is good only if using the image size specified during model conversion. These limitations may go away with further updates