### PR TITLE
Fix handling of embeddings with space in their name

### DIFF
--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -347,7 +347,7 @@ def load_embeddings(context, prompt, negative_prompt, default_pipe):
 
     for filename in pt_files + bin_files + st_files:
         skip_embedding = False
-        embeds_name =  get_embedding_token(filename.name)
+        embeds_name =  get_embedding_token(filename.name).lower()
         if (embeds_name not in prompt and embeds_name not in negative_prompt) or embeds_name in context._loaded_embeddings:
             continue
         log.info(f"### Load: embedding {filename} ###")

--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -10,6 +10,7 @@ from sdkit.utils import (
     apply_color_profile,
     base64_str_to_img,
     gc,
+    get_embedding_token,
     get_image_latent_and_mask,
     latent_samples_to_images,
     resize_img,
@@ -346,7 +347,7 @@ def load_embeddings(context, prompt, negative_prompt, default_pipe):
 
     for filename in pt_files + bin_files + st_files:
         skip_embedding = False
-        embeds_name =  filename.name.split(".")[0].lower()
+        embeds_name =  get_embedding_token(filename.name)
         if (embeds_name not in prompt and embeds_name not in negative_prompt) or embeds_name in context._loaded_embeddings:
             continue
         log.info(f"### Load: embedding {filename} ###")

--- a/sdkit/utils/__init__.py
+++ b/sdkit/utils/__init__.py
@@ -40,3 +40,6 @@ from .convert_model_utils import (
     convert_pipeline_unet_to_tensorrt,
 )
 from .device_utils import has_amd_gpu
+
+def get_embedding_token(filename):
+    return filename.split(".")[0].lower().replace(" ", "_")

--- a/sdkit/utils/__init__.py
+++ b/sdkit/utils/__init__.py
@@ -42,4 +42,4 @@ from .convert_model_utils import (
 from .device_utils import has_amd_gpu
 
 def get_embedding_token(filename):
-    return filename.split(".")[0].lower().replace(" ", "_")
+    return filename.split(".")[0].replace(" ", "_")


### PR DESCRIPTION
Replace space characters by underscore, since multi-word tokens don't work.