### PR TITLE
Preserve masked pixels from gradual inpainting degradation

### DIFF
--- a/sdkit/generate/image_generator.py
+++ b/sdkit/generate/image_generator.py
@@ -175,8 +175,8 @@ def img2img(
     # dramatic for larger images like 1024x1024. Now, this pixel space compositing approach isn't a panacea, as you can
     # often see a faint discontinuity around the masked area unless you use the feathered brush when drawing the
     # mask (regardless of whether color profile preservation is checked), but it at least guarantees that unchanged
-    # pixels remain unchanged so that you can reliably perform inpainting a dozen times to various parts. I posit there
-    # remains data loss somewhere deeper along the pipeline (maybe the VAE encode and decode is lossy, maybe denoising
+    # pixels remain unchanged so that you can reliably perform inpainting a dozen times to various parts. There remains
+    # data loss somewhere deeper along the pipeline (maybe the VAE decode and reencode is lossy, maybe the denoising
     # is not properly paying attention to the mask, maybe slight noise is being added where it shouldn't be...), but
     # this mitigates the issue until the root problem is identified.
     if init_image_mask != None:


### PR DESCRIPTION
## Problem
If you apply inpainting too many times to a generated image (because you know, 6 fingers 🤟 or 3 arms 💪 or such), the masked out parts of the image lose detail and become blurrier (https://github.com/easydiffusion/easydiffusion/issues/998). One inpainting may not be enough to notice (unless you put the two images side by side), but you'll notice after a few. e.g. See below inpaintings #‌1, #‌3, #‌5 how the eyelashes lose detail, hair loses shine, and ear tip rounds out:

![image](https://github.com/easydiffusion/easydiffusion/assets/1809166/83a1b80a-c450-49eb-b8a1-a16b16f0cc1a)

## Root cause?
🔎 Some precision is lost along the pipeline, but it's not clear yet where all it's leaking exactly 🤔:
- Does VAE encode/decode lose too much precision?
- Does it only happen for float16, or float32 too?
- Do some of the denoising algorithms not fully respect the mask?
- Is noise being applied where it shouldn't be?
- Why does the deterioration appear so much worse for 1024x1024 images than 512x512 images?...

One known loss is during VAE encode/decode because the downsampled 8x8 4-channel blocks in latent space cannot faithfully represent the original pixels for all possible input images when re-expanded later, but curiously additional loss occurs even to images that were generated from latent space in the first place (an earlier text2img), which you'd figure the 8x8 latent blocks could faithfully represent.

## Approach
This mitigation composites the final image with the original image in the pixel space as the last step in the pipeline. It's not a panacea because you can still often notice a faint discontinuity between the newly regenerated inpainted region and the preserved region (e.g. a tiny shade darker), even with color profile preservation enabled. It's not possible to *completely* avoid this because latent space can't fully represent pixel space, but using the feathered brush when drawing the mask diminishes the discontinuity visibility greatly.

## Other possible solutions
- Compositing in latent space each step instead of pixel space would *almost* work (assuming the 4 channels are indeed lerpable), but that doesn't guarantee unchanged pixels because of the VAE loss (plus it's an additional computation&copy every step).
- Compositing in pixel space by bilinear 8x8 blocks (via downsampling the mask 8x and then upsampling bilinearly 8x) could diminish mask edge discontinuities. The downside is that the mask couldn't have pixel precise accuracy anymore when wanted (not that it does today either :b, as `get_image_latent_and_mask` calls already `resize_img` to shrink the mask 8x smaller). It might be worth having a user-selectable option via config file to play around with 🤷, or we could just recommend to generally use the more feathery brushes when masking.