### PR TITLE
[sdkit.Context] Fallback to cpu device on Windows with AMD GPU

### DIFF
--- a/sdkit/__init__.py
+++ b/sdkit/__init__.py
@@ -1,13 +1,13 @@
 from threading import local
 from torch.cuda import is_available as cuda_available
-from .utils import log
+from logging import getLogger
 
 class Context(local):
     def __init__(self) -> None:
 
         self._device: str = 'cuda:0'
         if not cuda_available():
-            log.warning("CUDA device not found, fallback to cpu device.")
+            getLogger('sdkit').warning("CUDA device not found, fallback to cpu device.")
             self._device: str = 'cpu'
 
         self._half_precision: bool = True

--- a/sdkit/__init__.py
+++ b/sdkit/__init__.py
@@ -1,9 +1,15 @@
 from threading import local
-
+from torch.cuda import is_available as cuda_available
+from .utils import log
 
 class Context(local):
     def __init__(self) -> None:
-        self._device: str = "cuda:0"
+
+        self._device: str = 'cuda:0'
+        if not cuda_available():
+            log.warning("CUDA device not found, fallback to cpu device.")
+            self._device: str = 'cpu'
+
         self._half_precision: bool = True
         self._vram_usage_level = None
 


### PR DESCRIPTION
When trying to load a model with `load_model()` on Windows, having an AMD GPU (RX 7900XT),
the calling program crashes with error: "Torch was not compiled with CUDA", without falling back to cpu device.

Tested by installing torch packages using:
`pip3 install torch torchvision torchaudio`

This patch ensures the `sdkit.Context()` gets initialized with cpu device when cuda is not available.