### PR TITLE
allowing setuptools >= 69.5.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     install_requires=[
-        "setuptools==69.5.1",
+        "setuptools>=69.5.1",
         "stable-diffusion-sdkit==2.1.5",  # wrapper around stable-diffusion, to allow pip install
         "gfpgan",
         "piexif",


### PR DESCRIPTION
The fixed coded version of setuptools is quite out of date, allowing newer version make it possible to build other ED related packages, like torch, within the developer_console enviroment. Those packages expect bdist_wheel.py within the commands folder of setuptools, but is not bundeled in 69.5.1.